### PR TITLE
#70 update values after model built

### DIFF
--- a/hydromt_fiat/api/hydromt_fiat_vm.py
+++ b/hydromt_fiat/api/hydromt_fiat_vm.py
@@ -140,6 +140,38 @@ class HydroMtViewModel:
         region = self.data_catalog.get_geodataframe("area_of_interest")
         self.fiat_model.build(region={"geom": region}, opt=config_yaml.dict())
 
+        # Update exposure dataframe
+        buildings_gdf, roads_gdf = self.update_exposure_db(config_yaml)
+        return buildings_gdf, roads_gdf
+
+    def update_ground_floor_height(self, parameter):
+
+        #Update config yaml
+        self.save_data_catalog()
+        config_yaml = self.build_config_yaml()
+
+        # Update parameter with user-input
+        if parameter == "Finished Floor Height":
+            source = config_yaml.model_extra["update_ground_floor_height"].source
+            attribute_name = config_yaml.model_extra["update_ground_floor_height"].attribute_name
+            gfh_method = config_yaml.model_extra["update_ground_floor_height"].gfh_method
+            max_dist = config_yaml.model_extra["update_ground_floor_height"].max_dist
+            self.fiat_model.exposure.setup_ground_floor_height(source, attribute_name, gfh_method, max_dist)
+        elif parameter == "Additional Attributes":
+                print("holla")
+        elif parameter == "Ground Elevation":
+                print("holla")
+        elif parameter == "Max Potential Damages":
+                print("holla")
+
+        # Write model
+        self.fiat_model.write()
+
+        buildings_gdf, roads_gdf = self.update_exposure_db(config_yaml)
+        return buildings_gdf, roads_gdf
+        
+    # Update exposure dataframe
+    def update_exposure_db(self, config_yaml):
         exposure_db = self.fiat_model.exposure.exposure_db
         if (
             "setup_exposure_buildings" in config_yaml.dict()

--- a/hydromt_fiat/api/hydromt_fiat_vm.py
+++ b/hydromt_fiat/api/hydromt_fiat_vm.py
@@ -144,7 +144,7 @@ class HydroMtViewModel:
         buildings_gdf, roads_gdf = self.update_exposure_db(config_yaml)
         return buildings_gdf, roads_gdf
 
-    def update_ground_floor_height(self, parameter):
+    def update_model(self, parameter):
 
         #Update config yaml
         self.save_data_catalog()
@@ -158,12 +158,13 @@ class HydroMtViewModel:
             max_dist = config_yaml.model_extra["update_ground_floor_height"].max_dist
             self.fiat_model.exposure.setup_ground_floor_height(source, attribute_name, gfh_method, max_dist)
         elif parameter == "Additional Attributes":
-                print("holla")
+            print("holla")
         elif parameter == "Ground Elevation":
-                print("holla")
+            source = config_yaml.model_extra["update_ground_elevation"].source
+            self.fiat_model.exposure.setup_ground_elevation(source)
         elif parameter == "Max Potential Damages":
                 print("holla")
-
+    
         # Write model
         self.fiat_model.write()
 

--- a/hydromt_fiat/api/hydromt_fiat_vm.py
+++ b/hydromt_fiat/api/hydromt_fiat_vm.py
@@ -166,7 +166,7 @@ class HydroMtViewModel:
             source = config_yaml.model_extra["update_ground_elevation"].source
             self.fiat_model.exposure.setup_ground_elevation(source)
         elif parameter == "Max Potential Damages":
-                print("holla")
+                NotImplemented
     
         # Write model
         self.fiat_model.write()

--- a/hydromt_fiat/api/hydromt_fiat_vm.py
+++ b/hydromt_fiat/api/hydromt_fiat_vm.py
@@ -158,7 +158,10 @@ class HydroMtViewModel:
             max_dist = config_yaml.model_extra["update_ground_floor_height"].max_dist
             self.fiat_model.exposure.setup_ground_floor_height(source, attribute_name, gfh_method, max_dist)
         elif parameter == "Additional Attributes":
-            print("holla")
+            aggregation_area_fn = config_yaml.model_extra["setup_aggregation_areas"].aggregation_area_fn
+            attribute_names = config_yaml.model_extra["setup_aggregation_areas"].attribute_names
+            label_names = config_yaml.model_extra["setup_aggregation_areas"].label_names
+            self.fiat_model.setup_aggregation_areas(aggregation_area_fn, attribute_names, label_names)
         elif parameter == "Ground Elevation":
             source = config_yaml.model_extra["update_ground_elevation"].source
             self.fiat_model.exposure.setup_ground_elevation(source)


### PR DESCRIPTION
After a quickbuild or "model from scratch" is built and the user wants to update any parameters, 
the model will automatically updated after clicking "add to model" and the user does not create the model another time manually.

DelftDashboard PR: https://github.com/Deltares-research/DelftDashboard/pull/97

Note:
Max Potential Damages not implemented yet because it might take more effort due to content/structure 