### PR TITLE
corrected raise by for datum ref

### DIFF
--- a/hydromt_fiat/workflows/exposure_vector.py
+++ b/hydromt_fiat/workflows/exposure_vector.py
@@ -882,10 +882,10 @@ class ExposureVector(Exposure):
                 "Raising the ground floor height of the properties relative to Datum."
             )
             self.exposure_db.loc[
-                (self.exposure_db["Ground Floor Height"] < raise_by)
+                (self.exposure_db["Ground Floor Height"] + self.exposure_db["Ground Elevation"] < raise_by)
                 & self.exposure_db.index.isin(idx),
                 "Ground Floor Height",
-            ] = raise_by
+            ] += raise_by - (self.exposure_db["Ground Floor Height"] + self.exposure_db["Ground Elevation"])
 
         elif height_reference.lower() in ["geom", "table"]:
             # Elevate the objects relative to the surface water elevation map that the


### PR DESCRIPTION
Corrected raise by datum method:

Before it was checking if the ground flood height is larger than the raise by value value and if not it was giving the ground floor height the raise by value.

The corrected method checks if the total elevation of the object (**ground elevation + ground floor height**) is smaller than the raise by value and if yes, it changes the ground floor height to reach that level.

