### PR TITLE
dont allow multiple values, select first

### DIFF
--- a/hydromt_fiat/workflows/aggregation_areas.py
+++ b/hydromt_fiat/workflows/aggregation_areas.py
@@ -6,7 +6,7 @@ def process_value(value):
     if isinstance(value, list) and len(value) == 1:
         return value[0]
     elif isinstance(value, list) and len(value) > 1:
-        return ", ".join(value)
+        return int(value[0])
     else:
         return value
 


### PR DESCRIPTION
Now the first value of the zones is selected.

Should we support different options for the user to select or out of budget reasons leave it that way? 