### PR TITLE
fixed bug with multiple aggregation values type

### DIFF
--- a/hydromt_fiat/workflows/aggregation_areas.py
+++ b/hydromt_fiat/workflows/aggregation_areas.py
@@ -3,10 +3,8 @@ from typing import List, Union
 from pathlib import Path
 
 def process_value(value):
-    if isinstance(value, list) and len(value) == 1:
+    if isinstance(value, list):
         return value[0]
-    elif isinstance(value, list) and len(value) > 1:
-        return int(value[0])
     else:
         return value
 


### PR DESCRIPTION
There was a bug when multiple values were available for an object. Then a transformation to an integer was taken place, which cannot happen e.g. for sting variables (which is quit commonly the case with aggregation areas). 
@Santonia27, if there was not a specific reason to have that, I have now changed that to a general scematization that just takes the first value from a list, independent of the type.