### PR TITLE
corrected bug with indexing of block groups

### DIFF
--- a/hydromt_fiat/workflows/equity_data.py
+++ b/hydromt_fiat/workflows/equity_data.py
@@ -185,7 +185,7 @@ class EquityData:
             block_groups_list.append(block_groups_shp)
 
         #TODO Save final file as geopackage
-        self.block_groups = gpd.GeoDataFrame(pd.concat(block_groups_list))
+        self.block_groups = gpd.GeoDataFrame(pd.concat(block_groups_list)).reset_index(drop=True)
         
         # Create string from GEO_ID short 
         for index, row,in self.block_groups.iterrows():


### PR DESCRIPTION
in the PR #296, the index was used to update the names of the block groups to strings, but if there were more than one counties that needed to be merged here:
https://github.com/Deltares/hydromt_fiat/blob/361af602595a67eed3697f5a7bdd6fa073ecac1e/hydromt_fiat/workflows/equity_data.py#L188
 there were duplicated indices. 
Now the indices are reseted so it should not be a problem.