### PR TITLE
fixed bugs with indexing

### DIFF
--- a/tests/test_update_max_potential_damage.py
+++ b/tests/test_update_max_potential_damage.py
@@ -65,6 +65,12 @@ def test_update_max_potential_damage(case):
     updated_max_pot_damage["Object Name"] = updated_max_pot_damage[
         "Object Name"
     ].astype(int)
+
+    # Add Object ID to df
+    updated_max_pot_damage["Object ID"] =  updated_max_pot_damage["Object Name"]
+    cols = ['Object ID'] + [col for col in updated_max_pot_damage if col != 'Object ID']
+    updated_max_pot_damage = updated_max_pot_damage[cols]
+
     pd.testing.assert_frame_equal(
         updated_max_pot_damage,
         exposure_modified,


### PR DESCRIPTION
It seems that for a lot of the methods with respect to applying changes (elevating, changing max damage etc.) the indexing was not implemented in a safe way, assumng that always exposure objects are in asceding order based on Object ID.
This needs more attention but I started for now with some corrections.