### PR TITLE
Change readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -51,27 +51,32 @@ To create a new environment follow the steps below.
 - Create a new environment:
 
 .. code-block:: console
+    
     conda create -n hydromt_fiat python=3.11.*
 
 - Activate the environment:
 
 .. code-block:: console
-    conda activate hydromt_fiat`
+    
+    conda activate hydromt_fiat
 
 - Install conda-forge gdal.
 
 .. code-block:: console
+    
     conda install -c conda-forge gdal
 
 - Install Hydromt-FIAT from Github. After creating the new environment, you need to install all dependencies from the Deltares Github repository. You can use **pip install** to do so:
 
 .. code-block:: console
+    
     pip install git+https://github.com/Deltares/hydromt_fiat.git
 
 ### Existing environment
 If you want to install FIAT into an existing environment, simply activate the desired environment and run:
 
 .. code-block:: console
+    
     pip install git+https://github.com/Deltares/hydromt_fiat.git
 
 

--- a/README.rst
+++ b/README.rst
@@ -48,25 +48,25 @@ Hydromt-FIAT can be installled in an existing environment or the user can create
 New environment
 To create a new environment follow the steps below.
 
-- Create a new environment:
+1. Create a new environment:
 
 .. code-block:: console
     
     conda create -n hydromt_fiat python=3.11.*
 
-- Activate the environment:
+2. Activate the environment:
 
 .. code-block:: console
     
     conda activate hydromt_fiat
 
-- Install conda-forge gdal.
+3. Install conda-forge gdal.
 
 .. code-block:: console
     
     conda install -c conda-forge gdal
 
-- Install Hydromt-FIAT from Github. After creating the new environment, you need to install all dependencies from the Deltares Github repository. You can use **pip install** to do so:
+4. Install Hydromt-FIAT from Github. After creating the new environment, you need to install all dependencies from the Deltares Github repository. You can use **pip install** to do so:
 
 .. code-block:: console
     

--- a/README.rst
+++ b/README.rst
@@ -42,10 +42,10 @@ Installation
 
 ..   pip install hydromt_fiat 
 
-## For Use
+For Use HydroMT-FIAT, do:
 Hydromt-FIAT can be installled in an existing environment or the user can create a new environment. We recommened to create a new environment to avoid issues with other dependencies and packages.
 
-### New environment
+New environment
 To create a new environment follow the steps below.
 
 - Create a new environment:
@@ -72,7 +72,7 @@ To create a new environment follow the steps below.
     
     pip install git+https://github.com/Deltares/hydromt_fiat.git
 
-### Existing environment
+Existing environment
 If you want to install FIAT into an existing environment, simply activate the desired environment and run:
 
 .. code-block:: console

--- a/README.rst
+++ b/README.rst
@@ -30,8 +30,8 @@ for the Delft-FIAT_ model.
 .. _Delft-FIAT: https://www.deltares.nl/en/software-and-data/products/delft-fiat-flood-impact-assessment-tool
 
 
-Installation
-------------
+.. Installation
+.. ------------
 
 
 .. HydroMT-FIAT is available from pypi and will be added to conda-forge (in progress).
@@ -41,6 +41,9 @@ Installation
 .. .. code-block:: console
 
 ..   pip install hydromt_fiat 
+
+Installation as a User
+------------
 
 For Use HydroMT-FIAT, do:
 Hydromt-FIAT can be installled in an existing environment or the user can create a new environment. We recommened to create a new environment to avoid issues with other dependencies and packages.
@@ -80,6 +83,8 @@ If you want to install FIAT into an existing environment, simply activate the de
     pip install git+https://github.com/Deltares/hydromt_fiat.git
 
 
+Installation as a Developer
+------------
 For developing on HydroMT-FIAT, do:
 
 .. code-block:: console

--- a/README.rst
+++ b/README.rst
@@ -35,6 +35,8 @@ Installation
 
 HydroMT-FIAT is available from pypi and will be added to conda-forge (in progress).
 
+
+Please do not use this installation as it is currently under development. Instead do the developer installment, as explained below. 
 To install hydromt_fiat for usage, do:
 
 .. code-block:: console

--- a/README.rst
+++ b/README.rst
@@ -33,15 +33,51 @@ for the Delft-FIAT_ model.
 Installation
 ------------
 
-HydroMT-FIAT is available from pypi and will be added to conda-forge (in progress).
 
+.. HydroMT-FIAT is available from pypi and will be added to conda-forge (in progress).
 
-Please do not use this installation as it is currently under development. Instead do the developer installment, as explained below. 
-To install hydromt_fiat for usage, do:
+.. To install hydromt_fiat for usage, do:
 
-.. code-block:: console
+.. .. code-block:: console
 
-  pip install hydromt_fiat
+..   pip install hydromt_fiat 
+
+## For Use
+Hydromt-FIAT can be installled in an existing environment or the user can create a new environment. We recommened to create a new environment to avoid issues with other dependencies and packages.
+
+### New environment
+To create a new environment follow the steps below.
+
+- Create a new environment:
+
+```bash
+conda create -n hydromt_fiat python=3.11.*
+```
+- Activate the environment:
+
+```bash
+conda activate hydromt_fiat`
+```
+
+- Install conda-forge gdal.
+
+```bash
+conda install -c conda-forge gdal
+```
+
+- Install Hydromt-FIAT from Github. After creating the new environment, you need to install all dependencies from the Deltares Github repository. You can use **pip install** to do so:
+
+```bash
+pip install git+https://github.com/Deltares/hydromt_fiat.git
+```
+
+### Existing environment
+If you want to install FIAT into an existing environment, simply activate the desired environment and run:
+
+```bash
+pip install git+https://github.com/Deltares/hydromt_fiat.git
+```
+
 
 For developing on HydroMT-FIAT, do:
 

--- a/README.rst
+++ b/README.rst
@@ -51,28 +51,28 @@ To create a new environment follow the steps below.
 - Create a new environment:
 
 .. code-block:: console
-conda create -n hydromt_fiat python=3.11.*
+    conda create -n hydromt_fiat python=3.11.*
 
 - Activate the environment:
 
 .. code-block:: console
-conda activate hydromt_fiat`
+    conda activate hydromt_fiat`
 
 - Install conda-forge gdal.
 
 .. code-block:: console
-conda install -c conda-forge gdal
+    conda install -c conda-forge gdal
 
 - Install Hydromt-FIAT from Github. After creating the new environment, you need to install all dependencies from the Deltares Github repository. You can use **pip install** to do so:
 
 .. code-block:: console
-pip install git+https://github.com/Deltares/hydromt_fiat.git
+    pip install git+https://github.com/Deltares/hydromt_fiat.git
 
 ### Existing environment
 If you want to install FIAT into an existing environment, simply activate the desired environment and run:
 
 .. code-block:: console
-pip install git+https://github.com/Deltares/hydromt_fiat.git
+    pip install git+https://github.com/Deltares/hydromt_fiat.git
 
 
 For developing on HydroMT-FIAT, do:

--- a/README.rst
+++ b/README.rst
@@ -50,33 +50,29 @@ To create a new environment follow the steps below.
 
 - Create a new environment:
 
-```bash
+.. code-block:: console
 conda create -n hydromt_fiat python=3.11.*
-```
+
 - Activate the environment:
 
-```bash
+.. code-block:: console
 conda activate hydromt_fiat`
-```
 
 - Install conda-forge gdal.
 
-```bash
+.. code-block:: console
 conda install -c conda-forge gdal
-```
 
 - Install Hydromt-FIAT from Github. After creating the new environment, you need to install all dependencies from the Deltares Github repository. You can use **pip install** to do so:
 
-```bash
+.. code-block:: console
 pip install git+https://github.com/Deltares/hydromt_fiat.git
-```
 
 ### Existing environment
 If you want to install FIAT into an existing environment, simply activate the desired environment and run:
 
-```bash
+.. code-block:: console
 pip install git+https://github.com/Deltares/hydromt_fiat.git
-```
 
 
 For developing on HydroMT-FIAT, do:


### PR DESCRIPTION
The pypi version of hydromt fiat has a bug and is not running correctly. 
e need to update the versoin and make a new stable release!

Until then I updated the docs to install hydromt directly from the repo, same as it is done in fiat. 
I followed the installation process on my private machine and was finally able to run the JRC global notebook. (This works with the developer installation but not with the pip install hydromt fiat)

