### PR TITLE
Elevating new composite areas based on base flood maps bug fix

### DIFF
--- a/hydromt_fiat/workflows/exposure_vector.py
+++ b/hydromt_fiat/workflows/exposure_vector.py
@@ -1904,7 +1904,7 @@ class ExposureVector(Exposure):
         )
 
         # Ensure that the raise_by variable has the correct type
-        if raise_by is not pd.Series:
+        if not isinstance(raise_by, pd.Series):
             raise_by = pd.Series(raise_by, index=exposure_to_modify.index)
         
         # Find indices of properties that are below the required level

--- a/hydromt_fiat/workflows/exposure_vector.py
+++ b/hydromt_fiat/workflows/exposure_vector.py
@@ -1903,6 +1903,10 @@ class ExposureVector(Exposure):
             "Object ID", drop=False
         )
 
+        # Ensure that the raise_by variable has the correct type
+        if raise_by is not pd.Series:
+            raise_by = pd.Series(raise_by, index=exposure_to_modify.index)
+        
         # Find indices of properties that are below the required level
         properties_below_level = (
             exposure_to_modify.loc[:, "Ground Floor Height"]

--- a/hydromt_fiat/workflows/exposure_vector.py
+++ b/hydromt_fiat/workflows/exposure_vector.py
@@ -1920,7 +1920,7 @@ class ExposureVector(Exposure):
         original_df = exposure_to_modify.copy()  # to be used for metrics
         exposure_to_modify.loc[to_change, "Ground Floor Height"] = list(
             modified_objects_gdf.loc[to_change, attr_ref]
-            + raise_by
+            + raise_by[to_change]
             - exposure_to_modify.loc[to_change, "Ground Elevation"]
         )
 


### PR DESCRIPTION
There was a bug that did not allow for one of the composite areas to not be elevated in case it was already at high ground. This required to generalize the way the the raise_by varianle type was interpreted. 