### PR TITLE
Remove dask pin

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ authors = [
 ]
 requires-python = ">=3.8"
 dependencies = [
-    "hydromt<1.0",
+    "hydromt>=0.10.1,<1.0",
     "geopandas",
     "geopy",
     "numpy",
@@ -33,7 +33,6 @@ dependencies = [
     "tqdm",
     "pycountry-convert",
     "pyarrow",
-    "dask<=2024.12.1",
     "pint"
 ]
 readme = "README.rst"


### PR DESCRIPTION
I believe the dask pin is not needed anymore as hydromt core v0.10.1 supports newer versions of dask and xarray. Removing it would make it easier to install hydromt_fiat in conjunction with other hydromt plugins