### PR TITLE
fixed bug in get_full_gdf method

### DIFF
--- a/hydromt_fiat/workflows/exposure_vector.py
+++ b/hydromt_fiat/workflows/exposure_vector.py
@@ -2045,10 +2045,10 @@ class ExposureVector(Exposure):
             # NOTE: This is only used for the transition time from old to new models and for the translation script!
             if "Object ID" in self.exposure_geoms[0].columns:
                 assert set(self.exposure_geoms[0]["Object ID"]) == set(df["Object ID"])
+                gdf = self.exposure_geoms[0].merge(df, on="Object ID", how="left")
             else:
                 assert set(self.exposure_geoms[0]["object_id"]) == set(df["object_id"])
-            df["geometry"] = self.exposure_geoms[0]["geometry"]
-            gdf = gpd.GeoDataFrame(df, crs=self.exposure_geoms[0].crs)
+                gdf = self.exposure_geoms[0].merge(df, on="object_id", how="left")
         elif len(self.exposure_geoms) > 1:
             gdf_list = []
             for i in range(len(self.exposure_geoms)):


### PR DESCRIPTION
fixed bug for when I single geometry file is available where it was assumed that objects have the same order in the exposure table and geometry file

## Issue addressed
Fixes #<issue number>

## Explanation
Explain how you addressed the bug/feature request, what choices you made and why.

## Checklist
- [x] Updated tests or added new tests
- [x] Branch is up to date with `master`
- [x] Tests & pre-commit hooks pass
- [x] Updated documentation if needed

## Additional Notes (optional)
Add any additional notes or information that may be helpful.
