### PR TITLE
ensures that for each input geometry there is an output with the same name

### DIFF
--- a/hydromt_fiat/fiat.py
+++ b/hydromt_fiat/fiat.py
@@ -1748,6 +1748,10 @@ class FiatModel(GridModel):
                         f"exposure.geom.file{str(i+1)}",
                         fn.format(name=name),
                     )
+                    self.set_config(
+                        f"output.geom.name{str(i+1)}",
+                        f"{name}.gpkg",
+                    )
                     geom.to_file(_fn)
             if self.geoms:
                 GridModel.write_geoms(self)

--- a/hydromt_fiat/version.py
+++ b/hydromt_fiat/version.py
@@ -2,7 +2,7 @@
 
 major = 0
 minor = 5
-patch = 4
+patch = 5
 suffix = ""
 
 __version__ = f"{major}.{minor}.{patch}{suffix}"


### PR DESCRIPTION
This fix makes sure that during the config create, for each input file there will be an explicit output with the same name as the input as a geopackage format. 