### PR TITLE
fix building ground elevation

### DIFF
--- a/hydromt_fiat/workflows/gis.py
+++ b/hydromt_fiat/workflows/gis.py
@@ -329,7 +329,11 @@ def ground_elevation_from_dem(
         sampled_ids = da_exposure_id.raster.sample(
             nan_geoms.geometry.centroid
         )
-        gdf.loc[nan_geoms.index, "ground_elevtn"] = gdf.loc[sampled_ids.values, "ground_elevtn"].values
+        # fill the ground_elevtn column with the sampled values
+        valid_ids = np.isin(sampled_ids.values, gdf.index)
+        gdf.loc[nan_geoms.index[valid_ids], "ground_elevtn"] = gdf.loc[
+            sampled_ids.values[valid_ids], "ground_elevtn"
+        ].values
 
     # fill remaining nan values with its nearest geographical neighbor
     nan_geoms = gdf[gdf["ground_elevtn"].isna()]


### PR DESCRIPTION
## Issue addressed
Fixes #504, #503

## Explanation
- Fix the filling of missing values due to multiple buildings in the same cell. 
- Use the data_catalog for reading the DEM.
- Upgrade osmnx and dask versions. For osmnx, remove hardcoded "osmid" references
- Use representative points to get building footprint centroids as normal centroids might fall outside of building.

## Checklist
- [ ] Updated tests or added new tests
- [ ] Branch is up to date with `master`
- [ ] Tests & pre-commit hooks pass
- [ ] Updated documentation if needed

## Additional Notes (optional)
Add any additional notes or information that may be helpful.
