### PR TITLE
Update: Allow overriding exposure name in setup

### DIFF
--- a/src/hydromt_fiat/components/exposure_geom.py
+++ b/src/hydromt_fiat/components/exposure_geom.py
@@ -189,6 +189,7 @@ class ExposureGeomsComponent(GeomsComponent):
         exposure_fname: Path | str,
         exposure_type_column: str,
         *,
+        exposure_name: str | None = None,
         exposure_link_fname: Path | str | None = None,
         exposure_type_fill: str | None = None,
         predicate: str = "contains",
@@ -210,6 +211,11 @@ class ExposureGeomsComponent(GeomsComponent):
         exposure_type_column : str
             The name of column in the raw dataset that specifies the object type,
             e.g. the occupancy type.
+        exposure_name : str, optional
+            Name under which to store this exposure in the model. Also used as the
+            written filename stem and as the `exposure_geom` tag on vulnerability
+            identifiers. When None, the stem of `exposure_fname` is used.
+            By default None.
         exposure_link_fname : Path | str | None, optional
             The name of/ path to the dataset containing the mapping of the exposure
             types to the vulnerability data, by default None.
@@ -232,8 +238,8 @@ class ExposureGeomsComponent(GeomsComponent):
 use 'setup_region' before this method"
             )
 
-        # Get the name based on the stem of a path
-        name = Path(exposure_fname).stem
+        # Resolve the storage name: explicit override or stem of the source path
+        name = exposure_name if exposure_name is not None else Path(exposure_fname).stem
 
         # Get ze data
         exposure_data = self.model.data_catalog.get_geodataframe(

--- a/src/hydromt_fiat/components/exposure_grid.py
+++ b/src/hydromt_fiat/components/exposure_grid.py
@@ -174,6 +174,8 @@ class ExposureGridComponent(GridComponent):
         self,
         exposure_fnames: Path | str | list[Path | str],
         exposure_link_fname: Path | str | None = None,
+        *,
+        exposure_names: str | list[str | None] | None = None,
         expand: bool = True,
     ) -> None:
         """Set up an exposure grid.
@@ -185,6 +187,12 @@ class ExposureGridComponent(GridComponent):
         exposure_link_fname : Path | str, optional
             Table containing the names of the exposure files and corresponding
             vulnerability curves. By default None.
+        exposure_names : str | list[str | None], optional
+            Names under which to store the exposure variable(s) in the model. The
+            shape must match `exposure_fnames`. A `None` entry (or the whole arg)
+            falls back to the stem of the corresponding file. The chosen names are
+            also used to match against the `exposure_link_fname` linking table.
+            By default None.
         expand : bool, optional
             Whether to expand the hazard data to the bounding box of the model region.
             Nothing is done when the hazard data already covers the region.
@@ -214,10 +222,37 @@ before setting up exposure grid"
             else exposure_fnames
         )
 
+        # Normalise exposure_names to a list aligned with exposure_fnames
+        if exposure_names is None:
+            names_in: list[str | None] = [None] * len(exposure_fnames)
+        elif isinstance(exposure_names, str):
+            if len(exposure_fnames) != 1:
+                raise ValueError(
+                    "A scalar `exposure_names` is only valid when a single file "
+                    "is passed; provide a list aligned with `exposure_fnames`."
+                )
+            names_in = [exposure_names]
+        else:
+            if len(exposure_names) != len(exposure_fnames):
+                raise ValueError(
+                    f"`exposure_names` has length {len(exposure_names)} but "
+                    f"`exposure_fnames` has length {len(exposure_fnames)}."
+                )
+            names_in = list(exposure_names)
+
+        # Resolve names: explicit override per-element, else stem of the source path
+        resolved_names = [
+            n if n is not None else Path(f).stem
+            for n, f in zip(names_in, exposure_fnames)
+        ]
+        if len(set(resolved_names)) != len(resolved_names):
+            raise ValueError(
+                f"Resolved exposure names contain duplicates: {resolved_names}."
+            )
+
         # Read exposure data files from data catalog
         exposure_data = {}
-        for fname in exposure_fnames:
-            name = Path(fname).stem
+        for fname, name in zip(exposure_fnames, resolved_names):
             da = self.model.data_catalog.get_rasterdataset(
                 fname,
                 geom=self.model.region,

--- a/src/hydromt_fiat/components/exposure_grid.py
+++ b/src/hydromt_fiat/components/exposure_grid.py
@@ -175,7 +175,7 @@ class ExposureGridComponent(GridComponent):
         exposure_fnames: Path | str | list[Path | str],
         exposure_link_fname: Path | str | None = None,
         *,
-        exposure_names: str | list[str | None] | None = None,
+        rename: dict[str, str] | None = None,
         expand: bool = True,
     ) -> None:
         """Set up an exposure grid.
@@ -187,12 +187,12 @@ class ExposureGridComponent(GridComponent):
         exposure_link_fname : Path | str, optional
             Table containing the names of the exposure files and corresponding
             vulnerability curves. By default None.
-        exposure_names : str | list[str | None], optional
-            Names under which to store the exposure variable(s) in the model. The
-            shape must match `exposure_fnames`. A `None` entry (or the whole arg)
-            falls back to the stem of the corresponding file. The chosen names are
-            also used to match against the `exposure_link_fname` linking table.
-            By default None.
+        rename : dict[str, str], optional
+            Optional mapping from source-file stem to the name under which the
+            exposure variable should be stored (and matched against
+            `exposure_link_fname`). Only include entries you want to rename;
+            files absent from the mapping keep their file-stem name. Unknown
+            keys raise ``ValueError``. By default None.
         expand : bool, optional
             Whether to expand the hazard data to the bounding box of the model region.
             Nothing is done when the hazard data already covers the region.
@@ -222,29 +222,16 @@ before setting up exposure grid"
             else exposure_fnames
         )
 
-        # Normalise exposure_names to a list aligned with exposure_fnames
-        if exposure_names is None:
-            names_in: list[str | None] = [None] * len(exposure_fnames)
-        elif isinstance(exposure_names, str):
-            if len(exposure_fnames) != 1:
-                raise ValueError(
-                    "A scalar `exposure_names` is only valid when a single file "
-                    "is passed; provide a list aligned with `exposure_fnames`."
-                )
-            names_in = [exposure_names]
-        else:
-            if len(exposure_names) != len(exposure_fnames):
-                raise ValueError(
-                    f"`exposure_names` has length {len(exposure_names)} but "
-                    f"`exposure_fnames` has length {len(exposure_fnames)}."
-                )
-            names_in = list(exposure_names)
+        rename = rename or {}
+        stems = [Path(f).stem for f in exposure_fnames]
+        unknown = set(rename) - set(stems)
+        if unknown:
+            raise ValueError(
+                f"`rename` keys not found among exposure_fnames stems: "
+                f"{sorted(unknown)}. Known stems: {stems}."
+            )
 
-        # Resolve names: explicit override per-element, else stem of the source path
-        resolved_names = [
-            n if n is not None else Path(f).stem
-            for n, f in zip(names_in, exposure_fnames)
-        ]
+        resolved_names = [rename.get(stem, stem) for stem in stems]
         if len(set(resolved_names)) != len(resolved_names):
             raise ValueError(
                 f"Resolved exposure names contain duplicates: {resolved_names}."

--- a/tests/components/test_exposure_geom_component.py
+++ b/tests/components/test_exposure_geom_component.py
@@ -212,6 +212,47 @@ def test_exposure_geom_component_setup_no_link(
     assert f"{FN}_{DAMAGE}_structure" not in component.data["buildings"].columns
 
 
+def test_exposure_geom_component_setup_with_exposure_name(
+    model_exposure_setup: FIATModel,
+):
+    # Setup the component
+    component = ExposureGeomsComponent(model=model_exposure_setup)
+
+    # Setup the data with an explicit name override
+    component.setup(
+        exposure_fname="buildings",
+        exposure_type_column="gebruiksdoel",
+        exposure_name="residential",
+        exposure_link_fname="buildings_link",
+    )
+
+    # The renamed key replaces the catalog-source stem
+    assert "residential" in component.data
+    assert "buildings" not in component.data
+    assert len(component.data["residential"]) != 0
+    assert f"{FN}_{DAMAGE}_structure" in component.data["residential"].columns
+
+
+def test_exposure_geom_component_setup_with_exposure_name_no_link(
+    model_with_region: FIATModel,
+):
+    # Setup the component
+    component = ExposureGeomsComponent(model=model_with_region)
+
+    # Rename also applies on the un-linked code path
+    component.setup(
+        exposure_fname="buildings",
+        exposure_type_column="gebruiksdoel",
+        exposure_name="residential",
+        exposure_link_fname="buildings_link",
+        link_to_vulnerability=False,
+    )
+
+    assert "residential" in component.data
+    assert "buildings" not in component.data
+    assert len(component.data["residential"]) != 0
+
+
 def test_exposure_geom_component_setup_errors(
     model: FIATModel,
     build_region_small: Path,

--- a/tests/components/test_exposure_grid_component.py
+++ b/tests/components/test_exposure_grid_component.py
@@ -227,7 +227,7 @@ def test_exposure_grid_component_setup_errors(
         )
 
 
-def test_exposure_grid_component_setup_with_exposure_names_single(
+def test_exposure_grid_component_setup_with_rename_single(
     model_exposure_setup: FIATModel,
     tmp_path: Path,
 ):
@@ -245,7 +245,7 @@ def test_exposure_grid_component_setup_with_exposure_names_single(
     component.setup(
         exposure_fnames="industrial_content",
         exposure_link_fname=link_path,
-        exposure_names="industry",
+        rename={"industrial_content": "industry"},
     )
 
     # The renamed variable replaces the stem-derived one
@@ -254,7 +254,7 @@ def test_exposure_grid_component_setup_with_exposure_names_single(
     assert component.data.industry.attrs.get(FN_CURVE) == "in2"
 
 
-def test_exposure_grid_component_setup_with_exposure_names_multi(
+def test_exposure_grid_component_setup_with_rename_multi(
     model_exposure_setup: FIATModel,
     tmp_path: Path,
 ):
@@ -271,7 +271,10 @@ def test_exposure_grid_component_setup_with_exposure_names_multi(
     component.setup(
         exposure_fnames=["industrial_content", "industrial_structure"],
         exposure_link_fname=link_path,
-        exposure_names=["industry_c", "industry_s"],
+        rename={
+            "industrial_content": "industry_c",
+            "industrial_structure": "industry_s",
+        },
         expand=False,
     )
 
@@ -281,11 +284,11 @@ def test_exposure_grid_component_setup_with_exposure_names_multi(
     assert "industrial_structure" not in component.data.data_vars
 
 
-def test_exposure_grid_component_setup_with_exposure_names_partial(
+def test_exposure_grid_component_setup_with_rename_partial(
     model_exposure_setup: FIATModel,
     tmp_path: Path,
 ):
-    # One entry keeps the stem (None), the other is renamed
+    # Only one entry is renamed; the other keeps its stem
     link_path = tmp_path / "rename_link.csv"
     pd.DataFrame(
         {
@@ -299,7 +302,7 @@ def test_exposure_grid_component_setup_with_exposure_names_partial(
     component.setup(
         exposure_fnames=["industrial_content", "industrial_structure"],
         exposure_link_fname=link_path,
-        exposure_names=[None, "industry_s"],
+        rename={"industrial_structure": "industry_s"},
         expand=False,
     )
 
@@ -308,33 +311,19 @@ def test_exposure_grid_component_setup_with_exposure_names_partial(
     assert "industrial_structure" not in component.data.data_vars
 
 
-def test_exposure_grid_component_setup_with_exposure_names_mismatch(
+def test_exposure_grid_component_setup_with_rename_unknown_key(
     model_exposure_setup: FIATModel,
 ):
     component = ExposureGridComponent(model=model_exposure_setup)
 
-    with pytest.raises(ValueError, match="`exposure_names` has length"):
+    with pytest.raises(ValueError, match="not found among exposure_fnames stems"):
         component.setup(
             exposure_fnames=["industrial_content", "industrial_structure"],
-            exposure_names=["only_one"],
+            rename={"typo": "x"},
         )
 
 
-def test_exposure_grid_component_setup_with_exposure_names_scalar_multi(
-    model_exposure_setup: FIATModel,
-):
-    component = ExposureGridComponent(model=model_exposure_setup)
-
-    with pytest.raises(
-        ValueError, match="scalar `exposure_names` is only valid when a single file"
-    ):
-        component.setup(
-            exposure_fnames=["industrial_content", "industrial_structure"],
-            exposure_names="industry",
-        )
-
-
-def test_exposure_grid_component_setup_with_exposure_names_collision(
+def test_exposure_grid_component_setup_with_rename_collision(
     model_exposure_setup: FIATModel,
 ):
     component = ExposureGridComponent(model=model_exposure_setup)
@@ -342,5 +331,5 @@ def test_exposure_grid_component_setup_with_exposure_names_collision(
     with pytest.raises(ValueError, match="duplicates"):
         component.setup(
             exposure_fnames=["industrial_content", "industrial_structure"],
-            exposure_names=["dup", "dup"],
+            rename={"industrial_content": "dup", "industrial_structure": "dup"},
         )

--- a/tests/components/test_exposure_grid_component.py
+++ b/tests/components/test_exposure_grid_component.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 from unittest.mock import MagicMock, PropertyMock
 
+import pandas as pd
 import pytest
 import xarray as xr
 from hydromt.model import ModelRoot
@@ -13,9 +14,11 @@ from hydromt_fiat.utils import (
     EXPOSURE,
     EXPOSURE_GRID_FILE,
     EXPOSURE_GRID_SETTINGS,
+    EXPOSURE_LINK,
     FN_CURVE,
     GRID,
     MODEL_TYPE,
+    OBJECT_TYPE,
     VAR_AS_BAND,
     VULNERABILITY,
 )
@@ -221,4 +224,123 @@ def test_exposure_grid_component_setup_errors(
         component.setup(
             exposure_fnames="industrial_content",
             exposure_link_fname="",
+        )
+
+
+def test_exposure_grid_component_setup_with_exposure_names_single(
+    model_exposure_setup: FIATModel,
+    tmp_path: Path,
+):
+    # Build an ad-hoc linking table mapping the rename to a known identifier
+    link_path = tmp_path / "rename_link.csv"
+    pd.DataFrame(
+        {
+            EXPOSURE_LINK: ["industry"],
+            OBJECT_TYPE: ["industrial_content"],
+        }
+    ).to_csv(link_path, index=False)
+
+    component = ExposureGridComponent(model=model_exposure_setup)
+
+    component.setup(
+        exposure_fnames="industrial_content",
+        exposure_link_fname=link_path,
+        exposure_names="industry",
+    )
+
+    # The renamed variable replaces the stem-derived one
+    assert "industry" in component.data.data_vars
+    assert "industrial_content" not in component.data.data_vars
+    assert component.data.industry.attrs.get(FN_CURVE) == "in2"
+
+
+def test_exposure_grid_component_setup_with_exposure_names_multi(
+    model_exposure_setup: FIATModel,
+    tmp_path: Path,
+):
+    link_path = tmp_path / "rename_link.csv"
+    pd.DataFrame(
+        {
+            EXPOSURE_LINK: ["industry_c", "industry_s"],
+            OBJECT_TYPE: ["industrial_content", "industrial_structure"],
+        }
+    ).to_csv(link_path, index=False)
+
+    component = ExposureGridComponent(model=model_exposure_setup)
+
+    component.setup(
+        exposure_fnames=["industrial_content", "industrial_structure"],
+        exposure_link_fname=link_path,
+        exposure_names=["industry_c", "industry_s"],
+        expand=False,
+    )
+
+    assert "industry_c" in component.data.data_vars
+    assert "industry_s" in component.data.data_vars
+    assert "industrial_content" not in component.data.data_vars
+    assert "industrial_structure" not in component.data.data_vars
+
+
+def test_exposure_grid_component_setup_with_exposure_names_partial(
+    model_exposure_setup: FIATModel,
+    tmp_path: Path,
+):
+    # One entry keeps the stem (None), the other is renamed
+    link_path = tmp_path / "rename_link.csv"
+    pd.DataFrame(
+        {
+            EXPOSURE_LINK: ["industrial_content", "industry_s"],
+            OBJECT_TYPE: ["industrial_content", "industrial_structure"],
+        }
+    ).to_csv(link_path, index=False)
+
+    component = ExposureGridComponent(model=model_exposure_setup)
+
+    component.setup(
+        exposure_fnames=["industrial_content", "industrial_structure"],
+        exposure_link_fname=link_path,
+        exposure_names=[None, "industry_s"],
+        expand=False,
+    )
+
+    assert "industrial_content" in component.data.data_vars
+    assert "industry_s" in component.data.data_vars
+    assert "industrial_structure" not in component.data.data_vars
+
+
+def test_exposure_grid_component_setup_with_exposure_names_mismatch(
+    model_exposure_setup: FIATModel,
+):
+    component = ExposureGridComponent(model=model_exposure_setup)
+
+    with pytest.raises(ValueError, match="`exposure_names` has length"):
+        component.setup(
+            exposure_fnames=["industrial_content", "industrial_structure"],
+            exposure_names=["only_one"],
+        )
+
+
+def test_exposure_grid_component_setup_with_exposure_names_scalar_multi(
+    model_exposure_setup: FIATModel,
+):
+    component = ExposureGridComponent(model=model_exposure_setup)
+
+    with pytest.raises(
+        ValueError, match="scalar `exposure_names` is only valid when a single file"
+    ):
+        component.setup(
+            exposure_fnames=["industrial_content", "industrial_structure"],
+            exposure_names="industry",
+        )
+
+
+def test_exposure_grid_component_setup_with_exposure_names_collision(
+    model_exposure_setup: FIATModel,
+):
+    component = ExposureGridComponent(model=model_exposure_setup)
+
+    with pytest.raises(ValueError, match="duplicates"):
+        component.setup(
+            exposure_fnames=["industrial_content", "industrial_structure"],
+            exposure_names=["dup", "dup"],
         )


### PR DESCRIPTION
## Issue addressed
Fixes #607 

## Explanation
  Summary

  Adds an opt-in way to control how each exposure source is identified in the model, instead of forcing the file stem.

  - ExposureGeomsComponent.setup gains exposure_name: str | None. When set, it replaces the stem of exposure_fname as the component key, the written filename, and the exposure_geom tag on vulnerability identifiers.
  - ExposureGridComponent.setup gains rename: dict[str, str] | None — a partial mapping {source_stem: new_name}. Only the entries you want renamed need to appear; everything else keeps its stem. Unknown keys raise
  ValueError; duplicate resolved names raise ValueError. The renamed key drives the xarray variable name in the output dataset and the lookup into exposure_link_fname.

## Checklist
- [x] Updated tests or added new tests
- [x] Branch is up to date with `master`
- [x] Tests & pre-commit hooks pass
- [ ] Updated documentation if needed

## Additional Notes (optional)
Add any additional notes or information that may be helpful.
