### PR TITLE
Add:  unlinked_type_fill to keep features missing from vulnerability link

### DIFF
--- a/src/hydromt_fiat/components/exposure_geom.py
+++ b/src/hydromt_fiat/components/exposure_geom.py
@@ -191,6 +191,7 @@ class ExposureGeomsComponent(GeomsComponent):
         *,
         exposure_link_fname: Path | str | None = None,
         exposure_type_fill: str | None = None,
+        unlinked_type_fill: str | None = None,
         predicate: str = "contains",
         link_to_vulnerability: bool = True,
     ) -> None:
@@ -215,7 +216,15 @@ class ExposureGeomsComponent(GeomsComponent):
             types to the vulnerability data, by default None.
         exposure_type_fill : str, optional
             Value to which missing entries in the exposure type column will be mapped
-            to, if provided. By default None.
+            to, if provided. Operates on the first linking stage (raw type column ->
+            object type). By default None.
+        unlinked_type_fill : str, optional
+            Object type assigned to features whose object type (after the first
+            linking stage) has no matching entry in the vulnerability link table.
+            When provided and itself present in the vulnerability link table, those
+            features are remapped to this type and kept; otherwise they are dropped
+            with a warning. Only honored when `link_to_vulnerability` is True. By
+            default None.
         predicate : str, optional
             Method on how to select the data that falls within the region geometry.
             For more information see `geopandas.sjoin`. By default 'contains'.
@@ -256,9 +265,10 @@ use 'setup_region' before this method"
         )
         # Either link to vulnerability
         if link_to_vulnerability:
-            self.setup_link_vulnerability(
+            self._link_vulnerability(
                 exposure_name=name,
                 exposure_data=exposure_vector,
+                unlinked_type_fill=unlinked_type_fill,
             )
         # Or set the data directly
         else:
@@ -290,6 +300,19 @@ use 'setup_region' before this method"
             self._assert_entry(exposure_name)
             exposure_data = self.data[exposure_name]
 
+        self._link_vulnerability(
+            exposure_name=exposure_name,
+            exposure_data=exposure_data,
+        )
+
+    def _link_vulnerability(
+        self,
+        exposure_name: str,
+        exposure_data: gpd.GeoDataFrame,
+        *,
+        unlinked_type_fill: str | None = None,
+    ) -> None:
+        """Link exposure data to vulnerability and store back on the component."""
         # Check for vulnerability
         vulnerability = self.model.vulnerability.data
         if any([item.empty for item in vulnerability]):
@@ -300,6 +323,7 @@ use 'setup_region' before this method"
         exposure_vector = workflows.exposure_geoms_link_vulnerability(
             exposure_data=exposure_data,
             vulnerability=vulnerability.identifiers,
+            unlinked_type_fill=unlinked_type_fill,
         )
 
         # Set the data in the component

--- a/src/hydromt_fiat/workflows/exposure_geom.py
+++ b/src/hydromt_fiat/workflows/exposure_geom.py
@@ -118,6 +118,8 @@ these were removed"
 def exposure_geoms_link_vulnerability(
     exposure_data: gpd.GeoDataFrame,
     vulnerability: pd.DataFrame,
+    *,
+    unlinked_type_fill: str | None = None,
 ) -> gpd.GeoDataFrame:
     """Link the exposure data to the vulnerability data.
 
@@ -129,6 +131,11 @@ def exposure_geoms_link_vulnerability(
         The raw exposure data.
     vulnerability : pd.DataFrame
         The vulnerability identifier table to link up with.
+    unlinked_type_fill : str, optional
+        Object type assigned to features whose current `object_type` is absent
+        from the vulnerability link table. When provided (and present in the
+        vulnerability link table), those features are remapped to this type
+        instead of being dropped. By default None.
 
     Returns
     -------
@@ -143,6 +150,27 @@ def exposure_geoms_link_vulnerability(
 
     # Set the current size for a check later on
     data_m_size = len(exposure_data)
+
+    # Optionally remap features whose object_type is missing from the
+    # vulnerability link table so they survive the merge below.
+    if unlinked_type_fill is not None:
+        linked_types = set(vulnerability[EXPOSURE_LINK].unique())
+        if unlinked_type_fill not in linked_types:
+            logger.warning(
+                f"`unlinked_type_fill` value '{unlinked_type_fill}' is not present \
+in the vulnerability link table; unlinked features will still be dropped"
+            )
+        else:
+            unlinked_mask = ~exposure_data[OBJECT_TYPE].isin(linked_types)
+            n_unlinked = int(unlinked_mask.sum())
+            if n_unlinked > 0:
+                exposure_data = exposure_data.copy()
+                exposure_data.loc[unlinked_mask, OBJECT_TYPE] = unlinked_type_fill
+                logger.info(
+                    f"{n_unlinked} features had an exposure type not present in \
+the vulnerability link table; remapped to '{unlinked_type_fill}'"
+                )
+
     # Go through the unique new headers
     header_list = headers.unique().tolist()
     for header in header_list:

--- a/tests/components/test_exposure_geom_component.py
+++ b/tests/components/test_exposure_geom_component.py
@@ -17,6 +17,7 @@ from hydromt_fiat.utils import (
     FN,
     GEOM,
     MODEL_TYPE,
+    OBJECT_TYPE,
 )
 
 
@@ -248,6 +249,33 @@ def test_exposure_geom_component_setup_link(
     assert "foo" in component.data
     assert len(component.data["foo"]) == 12
     assert f"{FN}_{DAMAGE}_content" in component.data["foo"]
+
+
+def test_exposure_geom_component_setup_unlinked_fill(
+    model_exposure_setup: FIATModel,
+    exposure_vector_clipped_for_link: gpd.GeoDataFrame,
+):
+    # Setup the component
+    component = ExposureGeomsComponent(model=model_exposure_setup)
+
+    # Re-label the 'unknown' object_types to a value absent from the vulnerability
+    # link table, then go through the private helper that `setup()` uses when
+    # `unlinked_type_fill` is provided.
+    data = exposure_vector_clipped_for_link.copy()
+    data.loc[data[OBJECT_TYPE] == "unknown", OBJECT_TYPE] = "absent_type"
+
+    component._link_vulnerability(
+        exposure_name="foo",
+        exposure_data=data,
+        unlinked_type_fill="unknown",
+    )
+
+    # The previously-unmatched features are kept and carry the fill value
+    assert "foo" in component.data
+    assert len(component.data["foo"]) == 12
+    assert f"{FN}_{DAMAGE}_structure" in component.data["foo"].columns
+    assert "absent_type" not in component.data["foo"][OBJECT_TYPE].values
+    assert (component.data["foo"][OBJECT_TYPE] == "unknown").sum() == 3
 
 
 def test_exposure_geom_component_setup_link_data(

--- a/tests/workflows/test_exposure_geom.py
+++ b/tests/workflows/test_exposure_geom.py
@@ -173,6 +173,58 @@ def test_exposure_geoms_link_vulnerability_warnings(
     assert len(exposure_vector) == 9
 
 
+def test_exposure_geoms_link_vulnerability_fill(
+    caplog: pytest.LogCaptureFixture,
+    exposure_vector_data_link: gpd.GeoDataFrame,
+    vulnerability_identifiers: pd.DataFrame,
+):
+    # Rename the 'unknown' rows to a type that's not in the vulnerability link;
+    # then ask the workflow to fold them back to 'unknown' via the fill.
+    exposure_data = exposure_vector_data_link.replace("unknown", "absent_type")
+
+    exposure_vector = exposure_geoms_link_vulnerability(
+        exposure_data=exposure_data,
+        vulnerability=vulnerability_identifiers,
+        unlinked_type_fill="unknown",
+    )
+
+    # All features kept; no drop-warning emitted
+    assert len(exposure_vector) == 12
+    assert "could not be linked to vulnerability data" not in caplog.text
+    # Re-mapped features now carry the fill value
+    assert "absent_type" not in exposure_vector[OBJECT_TYPE].values
+    assert (exposure_vector[OBJECT_TYPE] == "unknown").sum() == 3
+    assert f"{FN}_{DAMAGE}_structure" in exposure_vector.columns
+    # And the fill features picked up a real curve
+    assert exposure_vector.loc[
+        exposure_vector[OBJECT_TYPE] == "unknown", f"{FN}_{DAMAGE}_structure"
+    ].notna().all()
+
+
+def test_exposure_geoms_link_vulnerability_fill_invalid(
+    caplog: pytest.LogCaptureFixture,
+    exposure_vector_data_link: gpd.GeoDataFrame,
+    vulnerability_identifiers: pd.DataFrame,
+):
+    # Use a fill value that itself is not in the vulnerability link table -- the
+    # workflow should warn about it and fall back to the existing drop behavior.
+    exposure_data = exposure_vector_data_link.replace("unknown", "absent_type")
+
+    exposure_vector = exposure_geoms_link_vulnerability(
+        exposure_data=exposure_data,
+        vulnerability=vulnerability_identifiers,
+        unlinked_type_fill="also_absent",
+    )
+
+    assert (
+        "`unlinked_type_fill` value 'also_absent' is not present in the \
+vulnerability link table"
+        in caplog.text
+    )
+    assert "3 features could not be linked to vulnerability data" in caplog.text
+    assert len(exposure_vector) == 9
+
+
 def test_exposure_geoms_add_columns(
     buildings_data: gpd.GeoDataFrame,
 ):

--- a/tests/workflows/test_exposure_geom.py
+++ b/tests/workflows/test_exposure_geom.py
@@ -196,9 +196,13 @@ def test_exposure_geoms_link_vulnerability_fill(
     assert (exposure_vector[OBJECT_TYPE] == "unknown").sum() == 3
     assert f"{FN}_{DAMAGE}_structure" in exposure_vector.columns
     # And the fill features picked up a real curve
-    assert exposure_vector.loc[
-        exposure_vector[OBJECT_TYPE] == "unknown", f"{FN}_{DAMAGE}_structure"
-    ].notna().all()
+    assert (
+        exposure_vector.loc[
+            exposure_vector[OBJECT_TYPE] == "unknown", f"{FN}_{DAMAGE}_structure"
+        ]
+        .notna()
+        .all()
+    )
 
 
 def test_exposure_geoms_link_vulnerability_fill_invalid(


### PR DESCRIPTION
## Issue addressed
Fixes #608 

## Explanation
  - `exposure_geoms.setup()` gains `unlinked_type_fill`: features whose `object_type` has no entry in the vulnerability link table are remapped to this fallback type (when it itself
  links) instead of being silently dropped.
  - Complements the existing `exposure_type_fill` (stage 1: raw type column → `object_type`); the new knob covers stage 2 (vulnerability linking).
  - `setup_link_vulnerability()` keeps its strict drop-unlinked contract — the fill is only surfaced on `setup()`.
  - Invalid fill values warn and fall back to the existing drop-with-warning path.
  
## Checklist
- [x] Updated tests or added new tests
- [x] Branch is up to date with `master`
- [x] Tests & pre-commit hooks pass
- [ ] Updated documentation if needed

## Additional Notes (optional)
Add any additional notes or information that may be helpful.
