### PR TITLE
Fix: don't drop features when vulnerability curves mix subtype/no-subtype

### DIFF
--- a/src/hydromt_fiat/components/exposure_geom.py
+++ b/src/hydromt_fiat/components/exposure_geom.py
@@ -298,10 +298,6 @@ use 'setup_region' before this method"
             # TODO Replace with custom error class
             raise RuntimeError("Run `vulnerability.setup` before this method")
 
-        # Impact type type conversion
-        if not isinstance(impact_type, list):
-            impact_type = [impact_type]
-
         # Call the workflow function to link the data
         exposure_vector = workflows.exposure_geoms_link_vulnerability(
             exposure_data=exposure_data,

--- a/src/hydromt_fiat/workflows/damage.py
+++ b/src/hydromt_fiat/workflows/damage.py
@@ -92,8 +92,16 @@ def max_monetary_damage(
     if IMPACT__SUBTYPE not in vulnerability.columns:
         headers = [""]
     else:
-        headers = vulnerability[vulnerability[IMPACT__TYPE] == impact_type]
-        headers = ["_" + str(item) for item in headers[IMPACT__SUBTYPE].unique()]
+        selected = vulnerability[vulnerability[IMPACT__TYPE] == impact_type]
+        # If the impact type is present but carries no subtype, 
+        # use a single bare header
+        subtypes = selected[IMPACT__SUBTYPE].dropna().unique()
+        if len(subtypes):
+            headers = ["_" + str(item) for item in subtypes]
+        elif len(selected):
+            headers = [""]
+        else:
+            headers = []
 
     # If not headers were found, log and return
     if len(headers) == 0:

--- a/src/hydromt_fiat/workflows/damage.py
+++ b/src/hydromt_fiat/workflows/damage.py
@@ -1,20 +1,20 @@
 """Calculate max potential damage based on exposure type."""
 
 import logging
-from itertools import product
 
 import geopandas as gpd
+import numpy as np
 import pandas as pd
 from hydromt.gis import utm_crs
 
 from hydromt_fiat.utils import (
     COST__TYPE,
     IMPACT__SUBTYPE,
-    IMPACT__TYPE,
     MAX,
     OBJECT__TYPE,
     create_query,
 )
+from hydromt_fiat.workflows.impact import filter_impact
 
 __all__ = ["max_monetary_damage"]
 
@@ -41,8 +41,8 @@ def max_monetary_damage(
         The existing exposure data.
     exposure_cost_table : pd.DataFrame
         The cost table.
-    exposure_type : str
-        Type of exposure data, e.g. 'damage'.
+    impact_type : str
+        Type of impact, e.g. 'damage' (monetary damage).
     vulnerability : pd.DataFrame
         The vulnerability identifier table.
     exposure_cost_link : pd.DataFrame, optional
@@ -59,6 +59,12 @@ def max_monetary_damage(
     """
     if exposure_cost_table is None:
         raise ValueError("Exposure costs table cannot be None")
+
+    # Select based on the impact type(s)
+    vulnerability = filter_impact(
+        vulnerability=vulnerability,
+        impact_type=impact_type,
+    )
 
     # Create a query from the kwargs
     if len(select) != 0:
@@ -88,30 +94,19 @@ def max_monetary_damage(
     exposure_cost_link = exposure_cost_link[[OBJECT__TYPE, COST__TYPE]]
     exposure_cost_link = exposure_cost_link.drop_duplicates(subset=OBJECT__TYPE)
 
-    # Get the unique headers corresponding to the 'exposure_type'
-    if IMPACT__SUBTYPE not in vulnerability.columns:
-        headers = [""]
-    else:
-        selected = vulnerability[vulnerability[IMPACT__TYPE] == impact_type]
-        # If the impact type is present but carries no subtype, 
-        # use a single bare header
-        subtypes = selected[IMPACT__SUBTYPE].dropna().unique()
-        if len(subtypes):
-            headers = ["_" + str(item) for item in subtypes]
-        elif len(selected):
-            headers = [""]
-        else:
-            headers = []
-
-    # If not headers were found, log and return
-    if len(headers) == 0:
-        raise ValueError(
-            f"Exposure type ({impact_type}) not found in vulnerability data"
-        )
+    # Get the unique headers corresponding to the 'exposure_type
+    maintypes = vulnerability[OBJECT__TYPE].to_numpy()
+    subtypes = np.full(maintypes.size, "")
+    if IMPACT__SUBTYPE in vulnerability:
+        sub = vulnerability[IMPACT__SUBTYPE]
+        subtypes = sub.mask(
+            sub.notna() & ~(sub == ""), "_" + sub.astype(str)
+        ).to_numpy()
+    # Combined as one string
+    combined = np.array([f"{x}{y}" for x, y in zip(maintypes, subtypes)])
 
     # Get unique linking names
-    unique_link = exposure_cost_link[COST__TYPE].unique().tolist()
-    unique_link = [f"{x}{y}" for x, y in product(unique_link, headers)]
+    unique_link = np.unique(combined)
     # Transpose the cost table, rename index to object_type to easily merge
     # This is not the object type, but the specific max costs of that element
     exposure_cost_table = exposure_cost_table.T.reset_index(names=COST__TYPE)
@@ -119,6 +114,8 @@ def max_monetary_damage(
     exposure_cost_table = exposure_cost_table[
         exposure_cost_table[COST__TYPE].isin(unique_link)
     ]
+    # Get the valid indices the other way around as well
+    valid = np.isin(combined, exposure_cost_table[COST__TYPE])
 
     # Link the cost type to the exposure data
     data_or_size = len(exposure_data)  # For size check later
@@ -138,17 +135,28 @@ def max_monetary_damage(
         exposure_data.to_crs(crs, inplace=True)
     area = exposure_data.area
 
+    # Create the columns
+    for st in set(subtypes):
+        exposure_data[f"{MAX}_{impact_type}{st}"] = np.nan
+
     # Loop through the headers to set the max damage per subtype (or not)
-    for header in headers:
-        data = exposure_data[COST__TYPE] + header
+    for mt, st in set(zip(maintypes[valid], subtypes[valid])):
+        mask = exposure_data[COST__TYPE] == mt
+        # Skip if main type (cost type is not found)
+        if not any(mask):
+            continue
+        data = exposure_data[COST__TYPE][mask] + st
         # Get the costs per object
         costs_per = data.to_frame().merge(exposure_cost_table, on=COST__TYPE)
         costs_per.drop(COST__TYPE, axis=1, inplace=True)
         costs_per = costs_per.squeeze()
         # Multiply by the area
-        costs_per *= area
+        costs_per *= area[mask].values
 
-        exposure_data[f"{MAX}_{impact_type}{header}"] = costs_per.astype(float)
+        # Set the values
+        exposure_data.loc[mask, f"{MAX}_{impact_type}{st}"] = costs_per.values.astype(
+            np.float64
+        )
 
     # Check data length afterwards
     data_m_size = len(exposure_data)

--- a/src/hydromt_fiat/workflows/exposure_geom.py
+++ b/src/hydromt_fiat/workflows/exposure_geom.py
@@ -15,6 +15,7 @@ from hydromt_fiat.utils import (
     OBJECT__ID,
     OBJECT__TYPE,
 )
+from hydromt_fiat.workflows.impact import filter_impact
 
 __all__ = [
     "exposure_geoms_add_columns",
@@ -135,7 +136,7 @@ defaulting to exposure data object type"
 def exposure_geoms_link_vulnerability(
     exposure_data: gpd.GeoDataFrame,
     vulnerability: pd.DataFrame,
-    impact_type: list[str],
+    impact_type: list[str] | str,
 ) -> gpd.GeoDataFrame:
     """Link the exposure data to the vulnerability data.
 
@@ -147,8 +148,8 @@ def exposure_geoms_link_vulnerability(
         The raw exposure data.
     vulnerability : pd.DataFrame
         The vulnerability identifier table to link up with.
-    impact_type : list[str]
-        The impact types to link for.
+    impact_type : str | list[str]
+        The impact type(s) to link for.
 
     Returns
     -------
@@ -157,19 +158,19 @@ def exposure_geoms_link_vulnerability(
     """
     logger.info("Linking the exposure data with the vulnerability data")
     # Select based on the impact type(s)
-    vulnerability = vulnerability[vulnerability[IMPACT__TYPE].isin(impact_type)]
-    if vulnerability.empty:
-        raise ValueError(
-            f"No data found in the vulnerability identifiers for these \
-impact types {impact_type}"
-        )
+    vulnerability = filter_impact(
+        vulnerability=vulnerability,
+        impact_type=impact_type,
+    )
 
     # Get the unique exposure types. Only append the subtype where a row
     # actually has one; rows without keep the bare impact type as header.
     headers = vulnerability[IMPACT__TYPE].astype(str)
     if IMPACT__SUBTYPE in vulnerability:
         sub = vulnerability[IMPACT__SUBTYPE]
-        headers = headers.mask(sub.notna(), headers + "_" + sub.astype(str))
+        headers = headers.mask(
+            sub.notna() & ~(sub == ""), headers + "_" + sub.astype(str)
+        )
 
     # Set the current size for a check later on
     data_m_size = len(exposure_data)

--- a/src/hydromt_fiat/workflows/exposure_geom.py
+++ b/src/hydromt_fiat/workflows/exposure_geom.py
@@ -164,10 +164,12 @@ def exposure_geoms_link_vulnerability(
 impact types {impact_type}"
         )
 
-    # Get the unique exposure types
-    headers = vulnerability[IMPACT__TYPE]
+    # Get the unique exposure types. Only append the subtype where a row
+    # actually has one; rows without keep the bare impact type as header.
+    headers = vulnerability[IMPACT__TYPE].astype(str)
     if IMPACT__SUBTYPE in vulnerability:
-        headers = vulnerability[IMPACT__TYPE] + "_" + vulnerability[IMPACT__SUBTYPE]
+        sub = vulnerability[IMPACT__SUBTYPE]
+        headers = headers.mask(sub.notna(), headers + "_" + sub.astype(str))
 
     # Set the current size for a check later on
     data_m_size = len(exposure_data)

--- a/src/hydromt_fiat/workflows/exposure_grid.py
+++ b/src/hydromt_fiat/workflows/exposure_grid.py
@@ -70,10 +70,12 @@ defaulting to the name of the exposure layer"
                 f"Missing column, '{col_name}' in exposure grid linking table"
             )
 
-    # Get the unique exposure types
-    headers = vulnerability[OBJECT__TYPE]
+    # Get the unique exposure types. Only append the subtype where a row
+    # actually has one; rows without it keep the bare object type as header.
+    headers = vulnerability[OBJECT__TYPE].astype(str)
     if IMPACT__SUBTYPE in vulnerability:
-        headers = vulnerability[OBJECT__TYPE] + "_" + vulnerability[IMPACT__SUBTYPE]
+        sub = vulnerability[IMPACT__SUBTYPE]
+        headers = headers.mask(sub.notna(), headers + "_" + sub.astype(str))
 
     # Loop through the the supplied data arrays
     for da_name, da in exposure_data.items():

--- a/src/hydromt_fiat/workflows/exposure_grid.py
+++ b/src/hydromt_fiat/workflows/exposure_grid.py
@@ -75,7 +75,9 @@ defaulting to the name of the exposure layer"
     headers = vulnerability[OBJECT__TYPE].astype(str)
     if IMPACT__SUBTYPE in vulnerability:
         sub = vulnerability[IMPACT__SUBTYPE]
-        headers = headers.mask(sub.notna(), headers + "_" + sub.astype(str))
+        headers = headers.mask(
+            sub.notna() & ~(sub == ""), headers + "_" + sub.astype(str)
+        )
 
     # Loop through the the supplied data arrays
     for da_name, da in exposure_data.items():

--- a/src/hydromt_fiat/workflows/impact.py
+++ b/src/hydromt_fiat/workflows/impact.py
@@ -1,0 +1,48 @@
+"""Some small impact functions."""
+
+import logging
+
+import numpy as np
+import pandas as pd
+
+from hydromt_fiat.utils import IMPACT__TYPE
+
+__all__ = ["filter_impact"]
+
+logger = logging.getLogger(f"hydromt.{__name__}")
+
+
+def filter_impact(
+    vulnerability: pd.DataFrame,
+    impact_type: str | list[str],
+) -> pd.DataFrame:
+    """Filter the vulnerability identifiers based on impact type.
+
+    Parameters
+    ----------
+    vulnerability : pd.DataFrame
+        The vulnvulnerability identifiers.
+    impact_type : str | list[str]
+        The impact type(s).
+
+    Returns
+    -------
+    pd.DataFrame
+        Filtered identifiers.
+    """
+    # Typing
+    if not isinstance(impact_type, list):
+        impact_type = [impact_type]
+    impact_type_ar = np.array(impact_type)
+
+    msg = "No data found in the vulnerability identifiers for these \
+impact types {types}"
+    # Filter
+    vulnerability = vulnerability[vulnerability[IMPACT__TYPE].isin(impact_type_ar)]
+    if vulnerability.empty:
+        raise ValueError(msg.format(types=impact_type))
+    check = np.isin(impact_type_ar, vulnerability[IMPACT__TYPE])
+    if not check.all():
+        logger.warning(msg.format(types=impact_type_ar[~check].tolist()))
+    # Return
+    return vulnerability

--- a/tests/workflows/test_damage.py
+++ b/tests/workflows/test_damage.py
@@ -1,4 +1,5 @@
 import logging
+import re
 
 import geopandas as gpd
 import pandas as pd
@@ -167,7 +168,10 @@ def test_max_monetary_damage_errors(
     # Select kwargs leave no data
     with pytest.raises(
         ValueError,
-        match=r"Exposure type \(affected\) not found in vulnerability data",
+        match=re.escape(
+            "No data found in the vulnerability identifiers for \
+these impact types ['affected']"
+        ),
     ):
         _ = max_monetary_damage(
             exposure_data=exposure_vector_clipped_for_damamge,

--- a/tests/workflows/test_impact.py
+++ b/tests/workflows/test_impact.py
@@ -1,0 +1,56 @@
+import logging
+import re
+
+import pandas as pd
+import pytest
+
+from hydromt_fiat.utils import OBJECT__TYPE
+from hydromt_fiat.workflows.impact import filter_impact
+
+
+def test_filter_impact(
+    vulnerability_identifiers: pd.DataFrame,
+):
+    # Call the function
+    v = filter_impact(
+        vulnerability=vulnerability_identifiers,
+        impact_type="damage",
+    )
+
+    # Assert the output
+    assert len(v) == 8
+    assert "residential" in v[OBJECT__TYPE].values
+
+
+def test_filter_impact_list(
+    caplog: pytest.LogCaptureFixture,
+    vulnerability_identifiers: pd.DataFrame,
+):
+    caplog.set_level(logging.WARNING)
+    # Call the function
+    v = filter_impact(
+        vulnerability=vulnerability_identifiers,
+        impact_type=["damage", "affected"],
+    )
+
+    # Assert the output
+    assert len(v) == 8
+    assert "residential" in v[OBJECT__TYPE].values
+    assert "No data found in the vulnerability identifiers" in caplog.text
+
+
+def test_filter_impact_errors(
+    vulnerability_identifiers: pd.DataFrame,
+):
+    # Ask for a nonsense impact type
+    with pytest.raises(
+        ValueError,
+        match=re.escape(
+            "No data found in the vulnerability identifiers for these \
+impact types ['foo']",
+        ),
+    ):
+        filter_impact(
+            vulnerability=vulnerability_identifiers,
+            impact_type="foo",
+        )


### PR DESCRIPTION
  ## Issue
  With `vulnerability.setup(merge=True)`, merging a subtype-less curve (e.g. road
  `outage`) into a subtype-aware set (JRC `damage` → `structure`/`content`) leaves the
  merged rows with `impact_subtype = NaN`. The header was built whenever the *column*
  existed, so those rows became `"outage" + "_" + NaN` → `NaN`, the `fn_*` join matched
  nothing, and every feature was dropped:
  `WARNING - 5378 features could not be linked to vulnerability data, these were removed`

  ## Fix
  Build the header from the subtype only on rows that actually have one, instead of
  whenever the column is present.

  - `exposure_geom.py` / `exposure_grid.py`: rows without a subtype keep the bare
    impact/object type as their header (so a merged-in subtype-less curve links on
    `fn_outage`); subtype-aware rows still split into `_structure`/`_content`.
  - `damage.py`: NaN subtypes are ignored, while distinguishing an impact type that is
    present but subtype-less (→ single bare header) from one that is absent
    (→ unchanged not-found error).