### PR TITLE
fix: write index for vulnerability curves

### DIFF
--- a/src/hydromt_fiat/components/vulnerability.py
+++ b/src/hydromt_fiat/components/vulnerability.py
@@ -202,13 +202,14 @@ no identifiers found at {read_path_id.as_posix()}"
         if not write_path.parent.is_dir():
             write_path.parent.mkdir(parents=True, exist_ok=True)
 
-        # Adjust the outgoing kwargs
-        if "index" not in kwargs:
-            kwargs["index"] = False
+        if kwargs.pop("index", None) is not None:
+            logger.warning(
+                "The 'index' argument is ignored when writing vulnerability data."
+            )
 
         # Write the file
         logger.info("Writing vulnerability data")
-        write_csv(data=self.data.curves, write_path=write_path, **kwargs)
+        write_csv(data=self.data.curves, write_path=write_path, index=True, **kwargs)
         # If not identifiers, skip writing
         if self.data.identifiers.empty:
             logger.info("No vulnerability identifiers encountered, skipping..")
@@ -216,6 +217,7 @@ no identifiers found at {read_path_id.as_posix()}"
             write_csv(
                 data=self.data.identifiers,
                 write_path=write_path.with_stem(f"{write_path.stem}_id"),
+                index=False,
                 **kwargs,
             )
 

--- a/src/hydromt_fiat/workflows/hazard.py
+++ b/src/hydromt_fiat/workflows/hazard.py
@@ -22,7 +22,7 @@ def hazard_setup(
     risk: bool = False,
     unit: str = "m",
 ) -> xr.Dataset:
-    """Read and transform hazard data.hazard_setup.
+    """Read and transform hazard data.
 
     Parameters
     ----------
@@ -41,7 +41,7 @@ def hazard_setup(
 
     Returns
     -------
-    xr.Dataset
+    xr.Dataset.hazard_setup.
         Unified xarray dataset containing the hazard data.
     """
     logger.info(f"Processing {hazard_type} hazard data")

--- a/src/hydromt_fiat/workflows/hazard.py
+++ b/src/hydromt_fiat/workflows/hazard.py
@@ -22,7 +22,7 @@ def hazard_setup(
     risk: bool = False,
     unit: str = "m",
 ) -> xr.Dataset:
-    """Read and transform hazard data.
+    """Read and transform hazard data.hazard_setup.
 
     Parameters
     ----------

--- a/src/hydromt_fiat/workflows/hazard.py
+++ b/src/hydromt_fiat/workflows/hazard.py
@@ -41,7 +41,7 @@ def hazard_setup(
 
     Returns
     -------
-    xr.Dataset.hazard_setup.
+    xr.Dataset
         Unified xarray dataset containing the hazard data.
     """
     logger.info(f"Processing {hazard_type} hazard data")

--- a/tests/components/test_vulnerability_component.py
+++ b/tests/components/test_vulnerability_component.py
@@ -287,28 +287,22 @@ def test_vulnerability_component_create_merge(model: FIATModel):
 
 
 def test_vulnerability_component_round_trip(tmp_path: Path, model: FIATModel):
+    # Arrange
     model.root.set(path=tmp_path, mode="r+")
-
-    # Setup the component
     component1 = VulnerabilityComponent(model=model)
-
-    # Assert it's empty
-    assert component1.data.curves.empty
-
-    # Setup the vulnerability
     component1.create(
         vulnerability_fname="jrc_curves",
         vulnerability_link_fname="jrc_curves_link",
         continent="europe",
     )
-    data_org = component1.data.curves.copy(deep=True)
 
-    # Write the data
+    # Write
     component1.write()
+
+    # Read
     component2 = VulnerabilityComponent(model=model)
-
-    # Read the data back
     component2.read()
-    data_read = component2.data.curves.copy(deep=True)
 
-    assert data_org.equals(data_read)
+    # Assert
+    eq, errors = component1.test_equal(component2)
+    assert eq, errors

--- a/tests/components/test_vulnerability_component.py
+++ b/tests/components/test_vulnerability_component.py
@@ -284,3 +284,31 @@ def test_vulnerability_component_create_merge(model: FIATModel):
     # Assert once more
     assert "curve2" in component.data.curves.columns
     assert len(component.data.curves.columns) == 2
+
+
+def test_vulnerability_component_round_trip(tmp_path: Path, model: FIATModel):
+    model.root.set(path=tmp_path, mode="r+")
+
+    # Setup the component
+    component1 = VulnerabilityComponent(model=model)
+
+    # Assert it's empty
+    assert component1.data.curves.empty
+
+    # Setup the vulnerability
+    component1.create(
+        vulnerability_fname="jrc_curves",
+        vulnerability_link_fname="jrc_curves_link",
+        continent="europe",
+    )
+    data_org = component1.data.curves.copy(deep=True)
+
+    # Write the data
+    component1.write()
+    component2 = VulnerabilityComponent(model=model)
+
+    # Read the data back
+    component2.read()
+    data_read = component2.data.curves.copy(deep=True)
+
+    assert data_org.equals(data_read)

--- a/tests/components/test_vulnerability_component.py
+++ b/tests/components/test_vulnerability_component.py
@@ -243,49 +243,6 @@ def test_vulnerability_component_write_sig(
     )
 
 
-def test_vulnerability_component_create(model: FIATModel):
-    # Setup the component
-    component = VulnerabilityComponent(model=model)
-
-    # Assert it's empty
-    assert component.data.curves.empty
-
-    # Setup the vulnerability
-    component.create(
-        vulnerability_fname="jrc_curves",
-        vulnerability_link_fname="jrc_curves_link",
-        continent="europe",
-    )
-
-    assert not component.data.curves.empty
-    assert not component.data.identifiers.empty
-
-
-def test_vulnerability_component_create_merge(model: FIATModel):
-    # Setup the component
-    component = VulnerabilityComponent(model=model)
-
-    # Assert it's empty
-    assert component.data.curves.empty
-
-    # Setup the vulnerability
-    component.create(
-        vulnerability_fname="curve1",
-    )
-    # Assert simply
-    assert "curve1" in component.data.curves.columns
-    assert len(component.data.curves.columns) == 1
-
-    # Once more but merge
-    component.create(
-        vulnerability_fname="curve2",
-        merge=True,
-    )
-    # Assert once more
-    assert "curve2" in component.data.curves.columns
-    assert len(component.data.curves.columns) == 2
-
-
 def test_vulnerability_component_round_trip(tmp_path: Path, model: FIATModel):
     # Arrange
     model.root.set(path=tmp_path, mode="r+")
@@ -330,3 +287,46 @@ def test_vulnerability_component_write_warnings(
         "The 'index' argument is ignored when writing vulnerability data."
         in caplog.text
     )
+
+
+def test_vulnerability_component_create(model: FIATModel):
+    # Setup the component
+    component = VulnerabilityComponent(model=model)
+
+    # Assert it's empty
+    assert component.data.curves.empty
+
+    # Setup the vulnerability
+    component.create(
+        vulnerability_fname="jrc_curves",
+        vulnerability_link_fname="jrc_curves_link",
+        continent="europe",
+    )
+
+    assert not component.data.curves.empty
+    assert not component.data.identifiers.empty
+
+
+def test_vulnerability_component_create_merge(model: FIATModel):
+    # Setup the component
+    component = VulnerabilityComponent(model=model)
+
+    # Assert it's empty
+    assert component.data.curves.empty
+
+    # Setup the vulnerability
+    component.create(
+        vulnerability_fname="curve1",
+    )
+    # Assert simply
+    assert "curve1" in component.data.curves.columns
+    assert len(component.data.curves.columns) == 1
+
+    # Once more but merge
+    component.create(
+        vulnerability_fname="curve2",
+        merge=True,
+    )
+    # Assert once more
+    assert "curve2" in component.data.curves.columns
+    assert len(component.data.curves.columns) == 2

--- a/tests/components/test_vulnerability_component.py
+++ b/tests/components/test_vulnerability_component.py
@@ -306,3 +306,27 @@ def test_vulnerability_component_round_trip(tmp_path: Path, model: FIATModel):
     # Assert
     eq, errors = component1.test_equal(component2)
     assert eq, errors
+
+
+def test_vulnerability_component_write_index_warning(
+    caplog: pytest.LogCaptureFixture,
+    tmp_path: Path,
+    model: FIATModel,
+):
+    caplog.set_level(logging.WARNING)
+    # Setup the component
+    component = VulnerabilityComponent(model=model)
+
+    # Set data like a dummy
+    component.create(
+        vulnerability_fname="jrc_curves",
+        vulnerability_link_fname="jrc_curves_link",
+        continent="europe",
+    )
+
+    component.write(index=False)
+
+    assert (
+        "The 'index' argument is ignored when writing vulnerability data."
+        in caplog.text
+    )

--- a/tests/components/test_vulnerability_component.py
+++ b/tests/components/test_vulnerability_component.py
@@ -308,7 +308,7 @@ def test_vulnerability_component_round_trip(tmp_path: Path, model: FIATModel):
     assert eq, errors
 
 
-def test_vulnerability_component_write_index_warning(
+def test_vulnerability_component_write_warnings(
     caplog: pytest.LogCaptureFixture,
     tmp_path: Path,
     model: FIATModel,


### PR DESCRIPTION
## Issue addressed
Fixes #650 

## Explanation
always write it for curves, never for identifiers

## Checklist
- [ ] Updated tests or added new tests
- [ ] Branch is up to date with `master`
- [ ] Tests & pre-commit hooks pass
- [ ] Updated documentation if needed

## Additional Notes (optional)
Add any additional notes or information that may be helpful.
