### PR TITLE
fix system test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -90,3 +90,34 @@ jobs:
       - name: Test
         run: |
           pixi run -e test-py${{ inputs.python-version }} test-integration
+
+  system:
+    defaults:
+      run:
+        shell: bash -e -l {0}
+    runs-on: ${{ inputs.os }}
+    needs: [unit, integration]
+    timeout-minutes: 30
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Setup pixi env
+        uses: prefix-dev/setup-pixi@28eb668aafebd9dede9d97c4ba1cd9989a4d0004
+        with:
+          pixi-version: "v0.70.1"
+          environments: test-py${{ inputs.python-version }}
+          locked: false
+          cache: true
+          cache-write: false
+
+      - name: Download cache
+        uses: actions/cache/restore@v5
+        with:
+          path: .cache
+          key: test-data
+          enableCrossOsArchive: true
+
+      - name: Test
+        run: |
+          pixi run -e test-py${{ inputs.python-version }} test-system

--- a/pixi.lock
+++ b/pixi.lock
@@ -1,7 +1,15 @@
 version: 7
 platforms:
 - name: linux-64
+  virtual-packages:
+  - __unix=0=0
+  - __linux=4.18
+  - __glibc=2.28
+  - __archspec=0=x86_64
 - name: win-64
+  virtual-packages:
+  - __win=10.0
+  - __archspec=0=x86_64
 environments:
   default:
     channels:
@@ -95,7 +103,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-magic-0.4.27-pyhd7f29a5_7.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.14-8_cp314.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
-      - pypi: .
+      - pypi: ./
+      - pypi: git+https://github.com/Deltares/Delft-FIAT.git?branch=v1#2282313e7dc387482278be3a6c273d3beea3363d
       - pypi: https://files.pythonhosted.org/packages/02/08/9c41fb51ab5b43eb21674aff13df270e8ba6c4b29c8624e328dc7a9482af/distlib-0.4.3-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/02/10/5da547df7a391dcde17f59520a231527b8571e6f46fc8efb02ccb370ab12/docutils-0.22.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/02/17/b82b537a30be67ba178fc0b0fbda8fcbaeda188fb039d6ad8a84e89353a2/dask-2026.6.0-py3-none-any.whl
@@ -127,7 +136,6 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/1a/82/a70006589557f267f15bd384c0642ad49f0d97b690c3a05b166b9dcbad3b/python_discovery-1.4.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/1b/dd/a9fe6a0a09512da23951c68bf36466aeecd89def3183dc095edbc807ddc5/pint-0.25.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/1c/78/504fdd027da3b84ff1aecd9f6957e65f35134534ccc6da8628eb71e76d3f/send2trash-2.1.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/1d/da/d8b44e26d29c9c49ea7eb7e9233ee23884710404618ee7199ecb808cb07b/delft_fiat-0.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/22/a6/858897256d0deac81a172289110f31629fc4cee19b6f01283303e18c8db3/ptyprocess-0.7.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/23/b4/4533091541c6620ecd68115bbfa1c61265b775618adef3a5fd137f4582e9/coverage-7.14.2-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl
@@ -402,7 +410,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/xerces-c-3.3.0-hac47afa_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/zlib-1.3.2-hfd05255_2.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/zstd-1.5.7-h534d264_6.conda
-      - pypi: .
+      - pypi: ./
+      - pypi: git+https://github.com/Deltares/Delft-FIAT.git?branch=v1#2282313e7dc387482278be3a6c273d3beea3363d
       - pypi: https://files.pythonhosted.org/packages/02/08/9c41fb51ab5b43eb21674aff13df270e8ba6c4b29c8624e328dc7a9482af/distlib-0.4.3-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/02/10/5da547df7a391dcde17f59520a231527b8571e6f46fc8efb02ccb370ab12/docutils-0.22.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/02/17/b82b537a30be67ba178fc0b0fbda8fcbaeda188fb039d6ad8a84e89353a2/dask-2026.6.0-py3-none-any.whl
@@ -435,7 +444,6 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/1a/f7/3a9e6389a7cfaeff76c56e40c2dabcb13110e21e82f837228c834ebe748c/matplotlib-3.11.0-cp314-cp314-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/1b/dd/a9fe6a0a09512da23951c68bf36466aeecd89def3183dc095edbc807ddc5/pint-0.25.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/1c/78/504fdd027da3b84ff1aecd9f6957e65f35134534ccc6da8628eb71e76d3f/send2trash-2.1.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/1d/da/d8b44e26d29c9c49ea7eb7e9233ee23884710404618ee7199ecb808cb07b/delft_fiat-0.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/22/d5/e605e4b28363e7a9ae98ed12cabbda5b155b6009270e6a231d8f10182a17/cftime-1.6.5-cp314-cp314-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/23/20/bb6982b26a40bb43951265ba29d4c246ef0ff59c9fdcdf0ed04e0687de4d/pyyaml-6.0.3-cp314-cp314-win_amd64.whl
@@ -677,7 +685,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/pip-26.1.2-pyh145f28c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.13-8_cp313.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
-      - pypi: .
+      - pypi: ./
       - pypi: https://files.pythonhosted.org/packages/02/10/5da547df7a391dcde17f59520a231527b8571e6f46fc8efb02ccb370ab12/docutils-0.22.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/02/17/b82b537a30be67ba178fc0b0fbda8fcbaeda188fb039d6ad8a84e89353a2/dask-2026.6.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/03/78/843bcf0cf31f88d2f8a9a063d2d80817b1901657d83d65b89b3aa835732e/nbsphinx-0.9.8-py3-none-any.whl
@@ -913,7 +921,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/vc14_runtime-14.51.36231-h1b9f54f_39.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/vcomp14-14.51.36231-h1b9f54f_39.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/zstd-1.5.7-h534d264_6.conda
-      - pypi: .
+      - pypi: ./
       - pypi: https://files.pythonhosted.org/packages/01/62/bfe3408743c9837919ff232474a09ece9eaa88d4ee8c040711fa3dff6dad/rasterio-1.5.0-cp313-cp313-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/01/ff/b46e2120abd99b2ff3d376dc91ed58ae8f0a052d57c242c9b140497573dd/cartopy-0.25.0-cp313-cp313-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/02/10/5da547df7a391dcde17f59520a231527b8571e6f46fc8efb02ccb370ab12/docutils-0.22.4-py3-none-any.whl
@@ -1152,7 +1160,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/pip-26.1.2-pyh145f28c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.14-8_cp314t.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
-      - pypi: .
+      - pypi: ./
       - pypi: https://files.pythonhosted.org/packages/02/17/b82b537a30be67ba178fc0b0fbda8fcbaeda188fb039d6ad8a84e89353a2/dask-2026.6.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/03/36/98ddbcf3e4f04a6dd07e1c67249955920579ba4af6bb6868e3088f4ed282/numba-0.65.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/03/41/4b9c02f99e4c5fb477122cd5437403b552873f014616ac1d19ac8221a58d/google_crc32c-1.8.0.tar.gz
@@ -1271,7 +1279,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/vc14_runtime-14.51.36231-h1b9f54f_39.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/vcomp14-14.51.36231-h1b9f54f_39.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/zstd-1.5.7-h534d264_6.conda
-      - pypi: .
+      - pypi: ./
       - pypi: https://files.pythonhosted.org/packages/02/17/b82b537a30be67ba178fc0b0fbda8fcbaeda188fb039d6ad8a84e89353a2/dask-2026.6.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/03/41/4b9c02f99e4c5fb477122cd5437403b552873f014616ac1d19ac8221a58d/google_crc32c-1.8.0.tar.gz
       - pypi: https://files.pythonhosted.org/packages/07/70/746ab7140121dcf04bade9ab7d2e65b6d5eb5b23bb7dc04b7ad22742ca0f/xugrid-0.15.3-py3-none-any.whl
@@ -1446,7 +1454,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-82.0.1-pyh332efcf_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/wheel-0.47.0-pyhd8ed1ab_0.conda
-      - pypi: .
+      - pypi: ./
+      - pypi: git+https://github.com/Deltares/Delft-FIAT.git?branch=v1#2282313e7dc387482278be3a6c273d3beea3363d
       - pypi: https://files.pythonhosted.org/packages/02/17/b82b537a30be67ba178fc0b0fbda8fcbaeda188fb039d6ad8a84e89353a2/dask-2026.6.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/07/70/746ab7140121dcf04bade9ab7d2e65b6d5eb5b23bb7dc04b7ad22742ca0f/xugrid-0.15.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/09/52/94108adfdd6e2ddf58be64f959a0b9c7d4ef2fa71086c38356d22dc501ea/argon2_cffi_bindings-25.1.0-cp39-abi3-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl
@@ -1462,7 +1471,6 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/19/f8/fcfb71b171746a8ab6f52c4bff6e9e4983b02ee050b16e5ea13a9bda2c61/pointpats-2.5.5-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/1b/dd/a9fe6a0a09512da23951c68bf36466aeecd89def3183dc095edbc807ddc5/pint-0.25.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/1c/1c/ab9510dfe1a16a35a10f90efad0d9a9cf61b9876973752968f2ba882f73f/coverage-7.14.2-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/1d/da/d8b44e26d29c9c49ea7eb7e9233ee23884710404618ee7199ecb808cb07b/delft_fiat-0.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/20/9c/d445818389df371f56d141d881153ba23183c4735a03f7356ffb43f7757d/aiohttp-3.14.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl
@@ -1634,7 +1642,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/xerces-c-3.3.0-hac47afa_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/zlib-1.3.2-hfd05255_2.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/zstd-1.5.7-h534d264_6.conda
-      - pypi: .
+      - pypi: ./
+      - pypi: git+https://github.com/Deltares/Delft-FIAT.git?branch=v1#2282313e7dc387482278be3a6c273d3beea3363d
       - pypi: https://files.pythonhosted.org/packages/02/17/b82b537a30be67ba178fc0b0fbda8fcbaeda188fb039d6ad8a84e89353a2/dask-2026.6.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/07/70/746ab7140121dcf04bade9ab7d2e65b6d5eb5b23bb7dc04b7ad22742ca0f/xugrid-0.15.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/0b/d0/a1b09cdea5211f8913406c0560a178fdea6ccbaea4511bbc248e9205f977/libpysal-4.14.1-py3-none-any.whl
@@ -1649,7 +1658,6 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/19/f8/fcfb71b171746a8ab6f52c4bff6e9e4983b02ee050b16e5ea13a9bda2c61/pointpats-2.5.5-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/1b/dd/a9fe6a0a09512da23951c68bf36466aeecd89def3183dc095edbc807ddc5/pint-0.25.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/1c/20/2fdec87fc7f8cec950d2b0bea603c12dc9f05b4966dc5924ba5a36a61bf6/numcodecs-0.16.5-cp312-cp312-win_amd64.whl
-      - pypi: https://files.pythonhosted.org/packages/1d/da/d8b44e26d29c9c49ea7eb7e9233ee23884710404618ee7199ecb808cb07b/delft_fiat-0.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/24/22/4daacd05391b92c55759d55eaee21e1dfaea86ce5c571f10083360adf534/tomli-2.4.1-cp312-cp312-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl
@@ -1840,7 +1848,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/pip-26.1.2-pyh145f28c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.13-8_cp313.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
-      - pypi: .
+      - pypi: ./
+      - pypi: git+https://github.com/Deltares/Delft-FIAT.git?branch=v1#2282313e7dc387482278be3a6c273d3beea3363d
       - pypi: https://files.pythonhosted.org/packages/02/17/b82b537a30be67ba178fc0b0fbda8fcbaeda188fb039d6ad8a84e89353a2/dask-2026.6.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/07/70/746ab7140121dcf04bade9ab7d2e65b6d5eb5b23bb7dc04b7ad22742ca0f/xugrid-0.15.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/07/f8/41db9de19d7987d6b04715a02b3b40aea467000275d9d758ffaa31af7d50/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
@@ -1855,7 +1864,6 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/19/f8/fcfb71b171746a8ab6f52c4bff6e9e4983b02ee050b16e5ea13a9bda2c61/pointpats-2.5.5-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/1b/dd/a9fe6a0a09512da23951c68bf36466aeecd89def3183dc095edbc807ddc5/pint-0.25.3-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/1d/da/d8b44e26d29c9c49ea7eb7e9233ee23884710404618ee7199ecb808cb07b/delft_fiat-0.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/1f/88/8dab5de10c638c083772a6be83a3d8106ced492f74a928c8693638e5bb50/scikit_learn-1.9.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl
@@ -2027,7 +2035,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/xerces-c-3.3.0-hac47afa_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/zlib-1.3.2-hfd05255_2.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/zstd-1.5.7-h534d264_6.conda
-      - pypi: .
+      - pypi: ./
+      - pypi: git+https://github.com/Deltares/Delft-FIAT.git?branch=v1#2282313e7dc387482278be3a6c273d3beea3363d
       - pypi: https://files.pythonhosted.org/packages/01/62/bfe3408743c9837919ff232474a09ece9eaa88d4ee8c040711fa3dff6dad/rasterio-1.5.0-cp313-cp313-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/02/17/b82b537a30be67ba178fc0b0fbda8fcbaeda188fb039d6ad8a84e89353a2/dask-2026.6.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/05/73/c4abe620b841b6b791f2edc248f556900667a5a1cf023a6646967ae98335/markupsafe-3.0.3-cp313-cp313-win_amd64.whl
@@ -2044,7 +2053,6 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/19/f8/fcfb71b171746a8ab6f52c4bff6e9e4983b02ee050b16e5ea13a9bda2c61/pointpats-2.5.5-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/1b/dd/a9fe6a0a09512da23951c68bf36466aeecd89def3183dc095edbc807ddc5/pint-0.25.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/1c/fd/3f0f10dba4dabad3bf53102be007abf55481067952bde0fdddff439e7c61/propcache-0.5.2-cp313-cp313-win_amd64.whl
-      - pypi: https://files.pythonhosted.org/packages/1d/da/d8b44e26d29c9c49ea7eb7e9233ee23884710404618ee7199ecb808cb07b/delft_fiat-0.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/20/3f/7917ca72464038f6240ec70c29f94862d08a34a74291ae4d4ec5eb8186a0/scikit_learn-1.9.0-cp313-cp313-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl
@@ -2234,7 +2242,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/pip-26.1.2-pyh145f28c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.14-8_cp314.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
-      - pypi: .
+      - pypi: ./
+      - pypi: git+https://github.com/Deltares/Delft-FIAT.git?branch=v1#2282313e7dc387482278be3a6c273d3beea3363d
       - pypi: https://files.pythonhosted.org/packages/02/17/b82b537a30be67ba178fc0b0fbda8fcbaeda188fb039d6ad8a84e89353a2/dask-2026.6.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/04/5f/9ff93450ba96b09c7c2b3f81c94de31c89f92292f1380261bd7195bea4ea/contourpy-1.3.3-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/05/1e/ada6fb15a1d75b5bd9b554355a69a798c55a7dcc93b8d41596265c1772e3/pyproj-3.7.2-cp314-cp314-manylinux_2_28_x86_64.whl
@@ -2250,7 +2259,6 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/19/f8/fcfb71b171746a8ab6f52c4bff6e9e4983b02ee050b16e5ea13a9bda2c61/pointpats-2.5.5-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/1b/dd/a9fe6a0a09512da23951c68bf36466aeecd89def3183dc095edbc807ddc5/pint-0.25.3-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/1d/da/d8b44e26d29c9c49ea7eb7e9233ee23884710404618ee7199ecb808cb07b/delft_fiat-0.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/23/b4/4533091541c6620ecd68115bbfa1c61265b775618adef3a5fd137f4582e9/coverage-7.14.2-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl
@@ -2421,7 +2429,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/xerces-c-3.3.0-hac47afa_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/zlib-1.3.2-hfd05255_2.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/zstd-1.5.7-h534d264_6.conda
-      - pypi: .
+      - pypi: ./
+      - pypi: git+https://github.com/Deltares/Delft-FIAT.git?branch=v1#2282313e7dc387482278be3a6c273d3beea3363d
       - pypi: https://files.pythonhosted.org/packages/02/17/b82b537a30be67ba178fc0b0fbda8fcbaeda188fb039d6ad8a84e89353a2/dask-2026.6.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/04/b2/5a6610554306a83a563080c2cf2c57565563eadd280e15388efa00fb5b33/pyproj-3.7.2-cp314-cp314-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/07/70/746ab7140121dcf04bade9ab7d2e65b6d5eb5b23bb7dc04b7ad22742ca0f/xugrid-0.15.3-py3-none-any.whl
@@ -2439,7 +2448,6 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/19/f8/fcfb71b171746a8ab6f52c4bff6e9e4983b02ee050b16e5ea13a9bda2c61/pointpats-2.5.5-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/1a/f7/3a9e6389a7cfaeff76c56e40c2dabcb13110e21e82f837228c834ebe748c/matplotlib-3.11.0-cp314-cp314-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/1b/dd/a9fe6a0a09512da23951c68bf36466aeecd89def3183dc095edbc807ddc5/pint-0.25.3-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/1d/da/d8b44e26d29c9c49ea7eb7e9233ee23884710404618ee7199ecb808cb07b/delft_fiat-0.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/22/d5/e605e4b28363e7a9ae98ed12cabbda5b155b6009270e6a231d8f10182a17/cftime-1.6.5-cp314-cp314-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/23/20/bb6982b26a40bb43951265ba29d4c246ef0ff59c9fdcdf0ed04e0687de4d/pyyaml-6.0.3-cp314-cp314-win_amd64.whl
@@ -2626,7 +2634,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/pip-26.1.2-pyh145f28c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.13-8_cp313.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
-      - pypi: https://files.pythonhosted.org/packages/1d/da/d8b44e26d29c9c49ea7eb7e9233ee23884710404618ee7199ecb808cb07b/delft_fiat-0.4.0-py3-none-any.whl
+      - pypi: git+https://github.com/Deltares/Delft-FIAT.git?branch=v1#2282313e7dc387482278be3a6c273d3beea3363d
       - pypi: https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/30/e1/c93444052cf41581f3c884ab3fb5823daf0992f11cd4388d4275ca610558/regex-2026.5.9-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
@@ -2642,6 +2650,8 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/eb/14/b3232ba218a0d1a70883d2675f18ff465de9e8e5e3346e81dc2b079838bd/coverage-7.14.2-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/ef/2f/c5464532e965badff2f4c4c1a3a83f5697f0d7c407ed0cda44aaa99bb451/certifi-2026.6.17-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/f6/af/e8fe5fb136f51e2b01678b92cb4106d10d8cd68ec147ead2e7cb0ac75398/scipy-1.18.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/f8/85/c2b1706e51942de19076eff082f8495e57d5151364e78b5bef4af4a1d94a/pyproj-3.7.2-cp313-cp313-manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/fa/07/330e3a0dda4c404d6da83b327270906e9654a24f6c546dc886a0eb0ffb23/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
       win-64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.6.17-h4c7d964_0.conda
@@ -2712,7 +2722,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/xerces-c-3.3.0-hac47afa_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/zlib-1.3.2-hfd05255_2.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/zstd-1.5.7-h534d264_6.conda
-      - pypi: https://files.pythonhosted.org/packages/1d/da/d8b44e26d29c9c49ea7eb7e9233ee23884710404618ee7199ecb808cb07b/delft_fiat-0.4.0-py3-none-any.whl
+      - pypi: git+https://github.com/Deltares/Delft-FIAT.git?branch=v1#2282313e7dc387482278be3a6c273d3beea3363d
       - pypi: https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/3a/31/6a620b4427d546b9e7cca8b3b8c5f0559d9cef2bb9eedcda7f73c1473c19/responses-0.26.1-py3-none-any.whl
@@ -2724,6 +2734,8 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/9d/7a/d968e294073affff457b041c2be9868a40c1c71f4a35fcc1e45e5493067b/pytest_cov-7.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a0/f4/c67b0b3f1b9245e8d266f0f112c500d50e5b4e83cb6f3b71b6528104182a/requests-2.34.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a6/47/1536d2b009c2848c3682500f497053f4645e70911afe02f594000997831a/coverage-7.14.2-cp313-cp313-win_amd64.whl
+      - pypi: https://files.pythonhosted.org/packages/b7/d2/ae881ee28d014f38e0ccbfd974a06a919ba9af34f1f74bf42b5301891d63/scipy-1.18.0-cp313-cp313-win_amd64.whl
+      - pypi: https://files.pythonhosted.org/packages/be/0f/747974129cf0d800906f81cd25efd098c96509026e454d4b66868779ab04/pyproj-3.7.2-cp313-cp313-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl
@@ -6260,7 +6272,7 @@ packages:
     - zstd >=1.5.7,<1.6.0a0
   size: 388453
   timestamp: 1764777142545
-- pypi: .
+- pypi: ./
   name: hydromt-fiat
   requires_dist:
   - affine
@@ -6296,6 +6308,34 @@ packages:
   - pytest-mock ; extra == 'test'
   - responses ; extra == 'test'
   requires_python: '>=3.12'
+- pypi: git+https://github.com/Deltares/Delft-FIAT.git?branch=v1#2282313e7dc387482278be3a6c273d3beea3363d
+  name: delft-fiat
+  version: 1.0.0.dev0
+  requires_dist:
+  - gdal>=3.5
+  - numpy
+  - pyproj
+  - scipy
+  - regex
+  - tomlkit ; extra == 'all'
+  - pyinstaller>=6.0.0 ; extra == 'build'
+  - build ; extra == 'dev'
+  - cython ; extra == 'dev'
+  - mypy ; extra == 'dev'
+  - pre-commit ; extra == 'dev'
+  - ruff ; extra == 'dev'
+  - setuptools>=61.0.0 ; extra == 'dev'
+  - griffe==1.15.0 ; extra == 'docs'
+  - jupyter ; extra == 'docs'
+  - jupyter-cache ; extra == 'docs'
+  - matplotlib ; extra == 'docs'
+  - pandas ; extra == 'docs'
+  - quartodoc==0.11.1 ; extra == 'docs'
+  - pytest>=2.7.3 ; extra == 'test'
+  - pytest-cov ; extra == 'test'
+  - pytest-mock ; extra == 'test'
+  - responses ; extra == 'test'
+  requires_python: '>=3.11'
 - pypi: https://files.pythonhosted.org/packages/01/62/bfe3408743c9837919ff232474a09ece9eaa88d4ee8c040711fa3dff6dad/rasterio-1.5.0-cp313-cp313-win_amd64.whl
   name: rasterio
   version: 1.5.0
@@ -7172,30 +7212,6 @@ packages:
   version: 0.5.2
   sha256: dfed59d0a5aeb01e242e66ff0300bc4a265a7c05f612d30016f0b60b1017d757
   requires_python: '>=3.10'
-- pypi: https://files.pythonhosted.org/packages/1d/da/d8b44e26d29c9c49ea7eb7e9233ee23884710404618ee7199ecb808cb07b/delft_fiat-0.4.0-py3-none-any.whl
-  name: delft-fiat
-  version: 0.4.0
-  sha256: 81ad733f11e0c1f5ee05cff807672b5d3306c408aff3c461675bc25d023461aa
-  requires_dist:
-  - gdal>=3.5
-  - numpy
-  - regex
-  - tomli-w ; extra == 'all'
-  - pyinstaller>=6.0.0 ; extra == 'build'
-  - cython ; extra == 'dev'
-  - pre-commit ; extra == 'dev'
-  - ruff ; extra == 'dev'
-  - setuptools>=61.0.0 ; extra == 'dev'
-  - jupyter ; extra == 'docs'
-  - jupyter-cache ; extra == 'docs'
-  - matplotlib ; extra == 'docs'
-  - pandas ; extra == 'docs'
-  - quartodoc>=0.7.6 ; extra == 'docs'
-  - pytest>=2.7.3 ; extra == 'test'
-  - pytest-cov ; extra == 'test'
-  - pytest-mock ; extra == 'test'
-  - responses ; extra == 'test'
-  requires_python: '>=3.11'
 - pypi: https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl
   name: idna
   version: '3.18'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -307,7 +307,8 @@ pandoc = "*"
 gdal = ">=3.9.1"
 
 [tool.pixi.feature.test.pypi-dependencies]
-delft_fiat = "*"
+delft_fiat = { git = "https://github.com/Deltares/Delft-FIAT.git", branch="v1" }
+
 
 [tool.pixi.feature.wheel.dependencies]
 pip = "*"

--- a/src/hydromt_fiat/components/exposure_geom.py
+++ b/src/hydromt_fiat/components/exposure_geom.py
@@ -215,10 +215,8 @@ class ExposureGeomsComponent(GeomsComponent):
         logger.info("Setting up exposure geometries")
         # Check for region
         if self.model.region is None:
-            # TODO Replace with custom error class
             raise MissingRegionError(
-                "Region is None -> \
-use 'setup_region' before this method"
+                "Region is None -> use 'set_region' before this method"
             )
 
         # Get the name based on the stem of a path

--- a/tests/components/test_exposure_geom_component.py
+++ b/tests/components/test_exposure_geom_component.py
@@ -222,7 +222,7 @@ def test_exposure_geom_component_create_errors(
     # Assert that no available region lead to an error
     with pytest.raises(
         MissingRegionError,
-        match="Region is None -> use 'setup_region' before this method",
+        match="Region is None -> use 'set_region' before this method",
     ):
         component.create(
             exposure_fname="bag",

--- a/tests/system/test_system_geom.py
+++ b/tests/system/test_system_geom.py
@@ -17,7 +17,7 @@ except ImportError:
 
 
 @pytest.mark.skipif(
-    not HAS_FIAT or Version(__version__) < Version("1"),
+    not HAS_FIAT or Version(__version__) < Version("1.0.0.dev0"),
     reason="At least Delft-FIAT version 1.0.0 is required.",
 )
 @pytest.mark.system
@@ -36,11 +36,11 @@ def test_system_geom_model(
     )
 
     # Add model type and region
-    model.setup_config(model_type=GEOM, calculation_method=FLOOD_LEVEL)
-    model.setup_region(build_region_small)
+    model.set_config(modeltype=GEOM, method=FLOOD_LEVEL)
+    model.set_region(build_region_small)
 
     # Setup the vulnerability
-    model.vulnerability.setup(
+    model.vulnerability.create(
         "jrc_curves",
         "jrc_curves_link",
         unit="m",
@@ -48,19 +48,19 @@ def test_system_geom_model(
     )
 
     # Add an hazard layer
-    model.hazard.setup(
+    model.hazard.create(
         "flood_event",
     )
 
     # Setup the exposure geometry data
-    model.exposure_geoms.setup(
+    model.exposure_geoms.create(
         exposure_fname="buildings",
         exposure_object_type_column="gebruiksdoel",
         exposure_link_fname="buildings_link",
     )
-    model.exposure_geoms.setup_max_damage(
+    model.exposure_geoms.create_max_damage(
         exposure_name="buildings",
-        exposure_type="damage",
+        impact_type="damage",
         exposure_cost_table_fname="jrc_damage",
         country="Netherlands",  # Select the correct row from the data
     )
@@ -77,6 +77,7 @@ def test_system_geom_model(
     ## FIAT
     # Read the config file
     cfg = Configurations.from_file(Path(model.root.path, model.config._filename))
+
     # Read the data in the fiat model
     fmodel = GeomModel(cfg)
 


### PR DESCRIPTION
We should run the system test with the latest of Delft-FIAT@v1 when working towards a true v1 release to catch errors early. 

After the release, we can go back to using true releases and no git deps, but for now its good as a canary-in-the-coalmine test

@dalmijn Could you fix the system test? 

Output of pixi run test-system:

<details>

```
PS C:\ProgramData\devdrive\repos\hydromt_fiat> pixi run test-system
Pixi task (test-system in default): pytest -m system --verbose
===================================== test session starts =====================================
platform win32 -- Python 3.14.6, pytest-9.1.1, pluggy-1.6.0 -- C:\ProgramData\devdrive\repos\hydromt_fiat\.pixi\envs\default\python.exe
cachedir: .pytest_cache
rootdir: C:\ProgramData\devdrive\repos\hydromt_fiat
configfile: pyproject.toml
testpaths: tests
plugins: anyio-4.14.0, cov-7.1.0, mock-3.15.1, zarr-3.2.1
collected 275 items / 274 deselected / 1 selected                                              

tests/system/test_system_geom.py::test_system_geom_model FAILED                          [100%]

========================================== FAILURES ===========================================
___________________________________ test_system_geom_model ____________________________________

tmp_path = WindowsPath('C:/Users/blom_lk/AppData/Local/Temp/pytest-of-blom_lk/pytest-2277/test_system_geom_model0')
build_data_catalog_path = WindowsPath('C:/ProgramData/devdrive/repos/hydromt_fiat/.cache/test-build-data/data_catalog.yml')
global_data_catalog_path = WindowsPath('C:/ProgramData/devdrive/repos/hydromt_fiat/.cache/global-data/data_catalog.yml')
build_region_small =     soortGroot sectie  ... statusHis1                                           geometry
0  Vastgesteld      L  ...     Geldig  MULTIPOLYGON (((86141.154 444422.745, 85849.34...

[1 rows x 21 columns]

    @pytest.mark.skipif(
        not HAS_FIAT or Version(__version__) < Version("1.0.0.dev0"),
        reason="At least Delft-FIAT version 1.0.0 is required.",
    )
    @pytest.mark.system
    def test_system_geom_model(
        tmp_path: Path,
        build_data_catalog_path: Path,
        global_data_catalog_path: Path,
        build_region_small: Path,
    ):
        ## HydroMT-FIAT
        # Setup the model
        model = FIATModel(
            root=tmp_path,
            mode="w+",
            data_libs=[build_data_catalog_path, global_data_catalog_path],
        )
    
        # Add model type and region
        model.set_config(modeltype=GEOM, method=FLOOD_LEVEL)
        model.set_region(build_region_small)
    
        # Setup the vulnerability
        model.vulnerability.create(
            "jrc_curves",
            "jrc_curves_link",
            unit="m",
            continent="europe",
        )
    
        # Add an hazard layer
        model.hazard.create(
            "flood_event",
        )
    
        # Setup the exposure geometry data
        model.exposure_geoms.create(
            exposure_fname="buildings",
            exposure_object_type_column="gebruiksdoel",
            exposure_link_fname="buildings_link",
        )
        model.exposure_geoms.create_max_damage(
            exposure_name="buildings",
            impact_type="damage",
            exposure_cost_table_fname="jrc_damage",
            country="Netherlands",  # Select the correct row from the data
        )
        # Needed for flood calculations
        model.exposure_geoms.update_column(
            exposure_name="buildings",
            columns=["ref", "method"],
            values=[0, "centroid"],
        )
    
        # Write the model
        model.write()
    
        ## FIAT
        # Read the config file
        cfg = Configurations.from_file(Path(model.root.path, model.config._filename))
    
        # Read the data in the fiat model
>       fmodel = GeomModel(cfg)
                 ^^^^^^^^^^^^^^

tests\system\test_system_geom.py:82: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
.pixi\envs\default\Lib\site-packages\fiat\model\geom.py:79: in __init__
    super().__init__(cfg)
.pixi\envs\default\Lib\site-packages\fiat\model\base.py:85: in __init__
    self.read_hazard_grid()
.pixi\envs\default\Lib\site-packages\fiat\model\base.py:203: in read_hazard_grid
    data = open_grid(path, **kw)
           ^^^^^^^^^^^^^^^^^^^^^
.pixi\envs\default\Lib\site-packages\fiat\fio\fopen.py:127: in open_grid
    return GridIO(
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <GridIO object at 0X0000017AF7360590>
file = WindowsPath('C:/Users/blom_lk/AppData/Local/Temp/pytest-of-blom_lk/pytest-2277/test_system_geom_model0/hazard.nc')
mode = 'r', srs = 'EPSG:28992', chunk = None, subset = None, var_as_band = False

    def __init__(
        self,
        file: str,
        mode: str = "r",
        srs: str | None = None,
        chunk: tuple = None,
        subset: str = None,
        var_as_band: bool = False,
    ):
        self.src: gdal.Dataset | None = None
        # Supercharge with BaseIO class
        BaseIO.__init__(self, file, mode)
    
        # Figure out the driver situation
        if self.path.suffix not in GRID_DRIVER_MAP:
>           raise DriverNotFoundError(gog="Grid", path=self.path)
E           fiat.error.DriverNotFoundError: Grid data -> Extension of file: hazard.nc not recoqnized

.pixi\envs\default\Lib\site-packages\fiat\fio\grid.py:83: DriverNotFoundError
------------------------------------ Captured stdout call -------------------------------------
[########################################] | 100% Completed | 107.14 ms
-------------------------------------- Captured log call --------------------------------------
WARNING  hydromt.hydromt_fiat.workflows.utils:utils.py:38 No known grid provided to reproject to, defaulting to first specified grid for transform and extent
WARNING  hydromt.hydromt_fiat.workflows.exposure_geom:exposure_geom.py:148 3 features could not be internally linked, these were removed. Unmapped values in 'gebruiksdoel': nan: 3
WARNING  hydromt.hydromt_fiat.components.geom:geom.py:208 'fid' column encountered in buildings, column will be removed
=================================== short test summary info ===================================
FAILED tests/system/test_system_geom.py::test_system_geom_model - fiat.error.DriverNotFoundError: Grid data -> Extension of file: hazard.nc not recoqnized
============================== 1 failed, 274 deselected in 2.13s ==============================
```